### PR TITLE
Fix build with gcc-13

### DIFF
--- a/core/hd_mapping_src/odo_with_gnss_fusion.cpp
+++ b/core/hd_mapping_src/odo_with_gnss_fusion.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <cstddef>
 #include <iostream>
+#include <iterator>
 #include <filesystem>
 
 #include <GL/freeglut.h>


### PR DESCRIPTION
While building on Debian unstable, I noticed that a header include was missing, which was apparently included implicitly before.
