### PR TITLE
Support for multilivox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,16 +221,23 @@ ${CORE_SRCS}
 ${GIZMO}
 )
 
-add_executable(mandeye_with_gopro_max_manual_coloring src/manual_color.cpp 
-							core/src/color_las_loader.cpp 
-							core/src/pfd_wrapper.cpp 
+add_executable(mandeye_with_gopro_max_manual_coloring src/manual_color.cpp
+							core/src/color_las_loader.cpp
+							core/src/pfd_wrapper.cpp
 							${IMGUI_SRCS}
-							) 
+							)
 
+
+add_executable(split_multi_livox tools/src/split_multi_livox.cpp)
+if (WIN32)
+target_link_libraries(split_multi_livox laszip3)
+else()
+target_link_libraries(split_multi_livox laszip)
+endif()
 
 if (WIN32)
 	target_link_libraries(mandeye_with_gopro_max_manual_coloring ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES} freeglut_static laszip3)
-	target_link_libraries(multi_session_registration_step_3 ${OPENGL_LIBRARIES} ../3rdparty/glew-2.2.0/lib/Release/x64/glew32 freeglut_static laszip3)	
+	target_link_libraries(multi_session_registration_step_3 ${OPENGL_LIBRARIES} ../3rdparty/glew-2.2.0/lib/Release/x64/glew32 freeglut_static laszip3)
 else()
 	target_link_libraries(mandeye_with_gopro_max_manual_coloring ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES} freeglut_static laszip tbb)
 	target_link_libraries(multi_session_registration_step_3 ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES} freeglut_static laszip tbb)

--- a/core/include/structures.h
+++ b/core/include/structures.h
@@ -71,8 +71,9 @@ struct Point3Di
 	//float y;
 	//float z;
 	double timestamp;
-    float intensity;
-    int index_pose;
+        float intensity;
+        int index_pose;
+        uint8_t lidarid;
 };
 
 struct Point

--- a/src/lidar_odometry.cpp
+++ b/src/lidar_odometry.cpp
@@ -67,7 +67,7 @@ void alternative_approach();
 
 void lidar_odometry_gui()
 {
-    if (ImGui::Begin("lidar_odometry_step_1 v0.30"))
+    if (ImGui::Begin("lidar_odometry_step_1 v0.31"))
     {
         ImGui::Text("This program is first step in MANDEYE process.");
         ImGui::Text("It results trajectory and point clouds as single session for 'multi_view_tls_registration_step_2' program.");
@@ -200,6 +200,29 @@ void lidar_odometry_gui()
                         {
                             std::cout << " -> " << sn << std::endl;
                         }
+                    }else{
+                        std::cout << "There is no calibration.json file in folder (check comment in source code) file: " << __FILE__ << " line: " << __LINE__ << std::endl;
+                        //example file for 2x livox";
+                        /*
+                        {
+                            "calibration" : {
+                                "47MDL9T0020193" : {
+                                    "identity" : "true"
+                                },
+                                "47MDL9S0020300" :
+                                    {
+                                        "order" : "ROW",
+                                        "inverted" : "TRUE",
+                                        "data" : [
+                                            0.999824, 0.00466397, -0.0181595, -0.00425984,
+                                            -0.0181478, -0.00254457, -0.999832, -0.151599,
+                                            -0.0047094, 0.999986, -0.00245948, -0.146408,
+                                            0, 0, 0, 1
+                                        ]
+                                    }
+                            },
+                                            "imuToUse" : "47MDL9T0020193"
+                        }*/
                     }
 
                     fs::path wdp = fs::path(input_file_names[0]).parent_path();

--- a/src/lidar_odometry.cpp
+++ b/src/lidar_odometry.cpp
@@ -168,6 +168,8 @@ void lidar_odometry_gui()
 
                 std::vector<std::string> csv_files;
                 std::vector<std::string> laz_files;
+                std::vector<std::string> sn_files;
+
                 std::for_each(std::begin(input_file_names), std::end(input_file_names), [&](const std::string &fileName)
                               {
                     if (fileName.ends_with(".laz") || fileName.ends_with(".las"))
@@ -177,11 +179,29 @@ void lidar_odometry_gui()
                     if (fileName.ends_with(".csv"))
                     {
                         csv_files.push_back(fileName);
-                    } });
+                    }
+                    if (fileName.ends_with(".sn"))
+                    {
+                        sn_files.push_back(fileName);
+                    }
+                    });
 
                 if (input_file_names.size() > 0 && laz_files.size() == csv_files.size())
                 {
                     working_directory = fs::path(input_file_names[0]).parent_path().string();
+
+                    const auto calibrationFile = (fs::path(working_directory) / "calibration.json").string();
+                    const auto preloadedCalibration = MLvxCalib::GetCalibrationFromFile(calibrationFile);
+                    const std::string imuSnToUse = MLvxCalib::GetImuSnToUse(calibrationFile);
+                    if (!preloadedCalibration.empty())
+                    {
+                        std::cout << "Loaded calibration for: \n";
+                        for (const auto& [sn, _] : preloadedCalibration)
+                        {
+                            std::cout << " -> " << sn << std::endl;
+                        }
+                    }
+
                     fs::path wdp = fs::path(input_file_names[0]).parent_path();
                     wdp /= "preview";
                     if (!fs::exists(wdp))
@@ -198,21 +218,61 @@ void lidar_odometry_gui()
                     std::cout << "loading imu" << std::endl;
                     std::vector<std::tuple<double, FusionVector, FusionVector>> imu_data;
 
-                    std::for_each(std::begin(csv_files), std::end(csv_files), [&imu_data](const std::string &fn)
-                                  {
-                    auto imu = load_imu(fn.c_str());
-                    std::cout << fn << std::endl;
-                    imu_data.insert(std::end(imu_data), std::begin(imu), std::end(imu)); });
+                    for (size_t fileNo = 0; fileNo < csv_files.size(); fileNo++)
+                    {
+                        const std::string& imufn = csv_files.at(fileNo);
+                        const std::string snFn = (fileNo>= sn_files.size())? ("") : (sn_files.at(fileNo));
+                        const auto idToSn = MLvxCalib::GetIdToSnMapping(snFn);
+                        // GetId of Imu to use
+                        int imuNumberToUse = MLvxCalib::GetImuIdToUse(idToSn, imuSnToUse);
+                        std::cout << "imuNumberToUse  " << imuNumberToUse <<  " at" << imufn << std::endl;
+                        auto imu = load_imu(imufn.c_str(), imuNumberToUse);
+                        std::cout << imufn <<" with mapping " << snFn << std::endl;
+                        imu_data.insert(std::end(imu_data), std::begin(imu), std::end(imu));
+                    }
 
                     std::cout << "loading points" << std::endl;
                     std::vector<std::vector<Point3Di>> pointsPerFile;
                     pointsPerFile.resize(laz_files.size());
-
+                    std::mutex mtx;
                     std::cout << "start std::transform" << std::endl;
-                    std::transform(std::execution::par_unseq, std::begin(laz_files), std::end(laz_files), std::begin(pointsPerFile), [](const std::string &fn)
-                                   { return load_point_cloud(fn.c_str(), true, params.filter_threshold_xy); });
+
+                    std::transform(std::execution::par_unseq, std::begin(laz_files), std::end(laz_files), std::begin(pointsPerFile), [&](const std::string& fn)
+                    {
+                            // Load mapping from id to sn
+                            fs::path fnSn(fn);
+                            fnSn.replace_extension(".sn");
+
+                            // GetId of Imu to use
+                            const auto idToSn = MLvxCalib::GetIdToSnMapping(fnSn.string());
+                            auto calibration = MLvxCalib::CombineIntoCalibration(idToSn, preloadedCalibration);
+                            auto data= load_point_cloud(fn.c_str(), true, params.filter_threshold_xy, calibration);
+
+                            if (fn == laz_files.front())
+                            {
+                                fs::path calibrationValidtationFile = wdp / "calibrationValidation.asc";
+
+                                std::ofstream testPointcloud{ calibrationValidtationFile.c_str() };
+                                for (const auto& p : data)
+                                {
+                                    testPointcloud << p.point.x() << "\t" << p.point.y() << "\t" << p.point.z() << "\t" << p.intensity << "\t" << (int) p.lidarid << "\n";
+
+                                }
+                            }
+
+
+							std::unique_lock lck(mtx);
+                            for (const auto& [id, calib] : calibration)
+                            {
+                                std::cout << " id : " << id << std::endl;
+                                std::cout << calib.matrix() << std::endl;
+                            }
+                            return data;
+							// std::cout << fn << std::endl;
+							//
+                    });
                     std::cout << "std::transform finished" << std::endl;
-                    
+
                     FusionAhrs ahrs;
                     FusionAhrsInitialise(&ahrs);
 
@@ -663,7 +723,7 @@ void lidar_odometry_gui()
                     for (size_t i = 0; i < input_file_names.size(); i++)
                     {
                         std::cout << "loading reference point cloud from: " << input_file_names[i] << std::endl;
-                        auto pp = load_point_cloud(input_file_names[i].c_str(), false, 0);
+                        auto pp = load_point_cloud(input_file_names[i].c_str(), false, 0, {});
                         std::cout << "loaded " << pp.size() << " reference points" << std::endl;
                         params.reference_points.insert(std::end(params.reference_points), std::begin(pp), std::end(pp));
                     }
@@ -1222,7 +1282,7 @@ int main(int argc, char *argv[])
 std::vector<std::vector<Point3Di>> get_batches_of_points(std::string laz_file, int point_count_threshold, std::vector<Point3Di> prev_points)
 {
     std::vector<std::vector<Point3Di>> res_points;
-    std::vector<Point3Di> points = load_point_cloud(laz_file, false, 0);
+    std::vector<Point3Di> points = load_point_cloud(laz_file, false, 0, {});
 
     std::vector<Point3Di> tmp_points = prev_points;
     int counter = tmp_points.size();
@@ -1341,7 +1401,7 @@ void find_best_stretch(std::vector<Point3Di> points, std::vector<double> timesta
     for (int i = 0; i < best_trajectory.size(); i++){
         trajectory_for_interpolation[ts[i]] = best_trajectory[i].matrix();
     }
-       
+
 
     std::vector<Point3Di> points_global = points_reindexed;
     for (auto &p : points_global)
@@ -1398,20 +1458,20 @@ void alternative_approach()
                     if (fileName.ends_with(".csv"))
                     {
                         csv_files.push_back(fileName);
-                    } 
+                    }
                 });
 
     std::cout << "imu files: " << std::endl;
     for (const auto &fn : csv_files){
         std::cout << fn << std::endl;
     }
-    
+
     std::cout << "loading imu" << std::endl;
     std::vector<std::tuple<double, FusionVector, FusionVector>> imu_data;
 
     std::for_each(std::begin(csv_files), std::end(csv_files), [&imu_data](const std::string &fn)
                   {
-                    auto imu = load_imu(fn.c_str());
+                    auto imu = load_imu(fn.c_str(), 0);
                     std::cout << fn << std::endl;
                     imu_data.insert(std::end(imu_data), std::begin(imu), std::end(imu)); });
 
@@ -1471,8 +1531,8 @@ void alternative_approach()
     /*int current_file_index = 0;
     int current_point_index = 0;
 
-    std::vector<Point3Di> points; 
-    
+    std::vector<Point3Di> points;
+
     bool do_not_stop = true;
     while (do_not_stop){
         bool do_not_stop_internal_loop = true;
@@ -1500,7 +1560,7 @@ void alternative_approach()
             all_points.push_back(tmp_points[j]);
         }
     }
-    
+
     //////////
     std::vector<double> timestamps;
     std::vector<Eigen::Affine3d> poses;

--- a/src/lidar_odometry_utils.h
+++ b/src/lidar_odometry_utils.h
@@ -64,6 +64,7 @@ struct LidarOdometryParams
     double sliding_window_trajectory_length_threshold = 50.0;
 };
 
+
 unsigned long long int get_index(const int16_t x, const int16_t y, const int16_t z);
 unsigned long long int get_rgd_index(const Eigen::Vector3d p, const Eigen::Vector3d b);
 // this function finds interpolated pose between two poses according to query_time
@@ -76,11 +77,26 @@ std::vector<Point3Di> decimate(const std::vector<Point3Di> &points, double bucke
 void update_rgd(NDT::GridParameters &rgd_params, NDTBucketMapType &buckets,
                 std::vector<Point3Di> &points_global, Eigen::Vector3d viewport = Eigen::Vector3d(0, 0, 0));
 
-//this function load inertial measurement unit data
-std::vector<std::tuple<double, FusionVector, FusionVector>> load_imu(const std::string &imu_file);
+//! This function load inertial measurement unit data.
+//! This function expects a file with the following format:
+//! timestamp angular_velocity_x angular_velocity_y angular_velocity_z linear_acceleration_x linear_acceleration_y linear_acceleration_z imu_id
+//! @note imu_id is an optional column, if not present, it is assumed that all data comes from the same IMU.
+//! @param imu_file - path to file with IMU data
+//! @param imuToUse - id number of IMU to use, the same index as in pointcloud return by @ref load_point_cloud
+//! @return vector of tuples (timestamp, angular_velocity, linear_acceleration)
+std::vector<std::tuple<double, FusionVector, FusionVector>> load_imu(const std::string &imu_file, int imuToUse);
 
-//this function load point cloud from LAS/LAZ file
-std::vector<Point3Di> load_point_cloud(const std::string &lazFile, bool ommit_points_with_timestamp_equals_zero, double filter_threshold_xy);
+//! This function load point cloud from LAS/LAZ file.
+//! Optionally it can apply extrinsic calibration to each point.
+//! The calibration is stored in a map, where key is laser scanner id.
+//! The id of the laser scanner is stored in LAS/LAZ file as `user_data` field.
+//! @param lazFile - path to file with point cloud
+//! @param ommit_points_with_timestamp_equals_zero - if true, points with timestamp == 0 will be omited
+//! @param filter_threshold_xy - threshold for filtering points in xy plane
+//! @param calibrations - map of calibrations for each scanner key is scanner id.
+//! @return vector of points of @ref Point3Di type
+std::vector<Point3Di> load_point_cloud(const std::string &lazFile, bool ommit_points_with_timestamp_equals_zero, double filter_threshold_xy,
+                                       const std::unordered_map<int, Eigen::Affine3d>& calibrations);
 
 
 bool saveLaz(const std::string &filename, const WorkerData &data);
@@ -105,4 +121,81 @@ void fix_ptch_roll(std::vector<WorkerData> &worker_data);
 
 void compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams& params);
 void compute_step_2_fast_forward_motion(std::vector<WorkerData> &worker_data, LidarOdometryParams &params);
+
+//! This namespace contains functions for loading calibration file (.json and .sn).
+//!
+//! Calibration file is a json file with the following format:
+//!{```json
+//!    "calibration": {
+//!      "47MDL9T0020193": {
+//!        "identity" : "true"
+//!      },
+//!      "47MDL9S0020300":
+//!          {
+//!            "order" : "ROW",
+//!            "inverted" : "TRUE",
+//!            "data":[
+//!             0.999824, 0.00466397, -0.0181595, -0.00425984,
+//!             -0.0181478, -0.00254457, -0.999832, -0.151599,
+//!              -0.0047094,0.999986, -0.00245948, -0.146408,
+//!              0, 0, 0, 1
+//!            ]
+//!          }
+//!    },
+//!                    "imuToUse": "47MDL9T0020193"
+//!}```
+//! Json object `calibration` contains a map of calibration for each sensor.
+//! The key of the map is serial number of the sensor.
+//! The value is a json object with the following fields:
+//! - `identity` - if true, the calibration is identity matrix
+//!  - `order` - order of the matrix, can be `ROW` or `COLUMN`
+//!  - `inverted` - if true, the calibration matrix is inverted
+//!  - `data` - calibration matrix in given order
+//! Json object `imuToUse` contains serial number of the sensor to use for IMU.
+//! The JSON file contains mapping from sensor id to serial number to calibration.
+//! The sensor id is the id of the point in LAS/LAZ file.
+//!
+//! The MANDEYE_CONTROLLER saves the sensor id in `user_data` field of LAZ file,
+//! and also saves the serial number of the sensors in .sn file.
+//! The .sn file is a text file with the following format:
+//! ```text
+//! 0 47MDL9T0020193
+//! 1 47MDL9S0020300
+//! ```
+//! The first column is sensor id, the second column is serial number.
+//! It is a mapping from lidarid (used in LAZ file) to serial number.
+//! Those two files allows to apply calibration to each point in LAZ file.
+namespace MLvxCalib {
+
+//! Parse the calibration file and return a map from sensor id to serial number.
+//! Sensor id is the id is id of the point in laz file.
+//! Serial number is the serial number of the Livox.
+//! @param filename calibration file
+//! @return map of serial number, where key is sensor id.
+std::unordered_map<int, std::string> GetIdToSnMapping(const std::string& filename);
+
+//! Parse the calibration file and return a map from serial number to calibration.
+//! @param filename calibration file
+//! @return map of extrinsic calibration, where key is serial number of the lidar.
+std::unordered_map<std::string, Eigen::Affine3d> GetCalibrationFromFile(const std::string& filename);
+
+//! Parse the calibration file and return a serial number of the Livox to use for IMU.
+//! @param filename calibration file
+//! @return serial number of the Livox to use for IMU
+std::string GetImuSnToUse(const std::string& filename);
+
+//! Combine the id to serial number mapping and the calibration into a single map.
+//! The single map is from sensor id to calibration.
+//! @param idToSn mapping from serial number to Id number in pointcloud or IMU CSV
+//! @param calibration map of extrinsic calibration, where key is serial number of the lidar.
+//! @return map from sensor id to extrinsic calibration
+std::unordered_map<int, Eigen::Affine3d> CombineIntoCalibration(const std::unordered_map<int, std::string>& idToSn,
+                                                                const std::unordered_map<std::string, Eigen::Affine3d>& calibration);
+//! Get the id of the IMU to use.
+//! @param idToSn mapping from serial number to Id number in pointcloud or IMU CSV
+//! @param snToUse serial number of the Livox to use for IMU
+//! @return id of the IMU to use
+int GetImuIdToUse(const std::unordered_map<int, std::string>& idToSn, const std::string& snToUse );
+
+}
 #endif

--- a/src/multi_session_registration.cpp
+++ b/src/multi_session_registration.cpp
@@ -1715,7 +1715,7 @@ bool initGL(int *argc, char **argv)
     glutInit(argc, argv);
     glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE);
     glutInitWindowSize(window_width, window_height);
-    glutCreateWindow("multi_session_registration_step_3 v0.30");
+    glutCreateWindow("multi_session_registration_step_3 v0.31");
     glutDisplayFunc(display);
     glutMotionFunc(motion);
 

--- a/src/multi_view_tls_registration.cpp
+++ b/src/multi_view_tls_registration.cpp
@@ -3308,7 +3308,7 @@ bool initGL(int *argc, char **argv)
     glutInit(argc, argv);
     glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE);
     glutInitWindowSize(window_width, window_height);
-    glutCreateWindow("multi_view_tls_registration_step_2 v0.30");
+    glutCreateWindow("multi_view_tls_registration_step_2 v0.31");
     glutDisplayFunc(display);
     glutMotionFunc(motion);
 

--- a/tools/src/split_multi_livox.cpp
+++ b/tools/src/split_multi_livox.cpp
@@ -1,0 +1,333 @@
+#include <string>
+#include <vector>
+#include <laszip/laszip_api.h>
+#include <Eigen/Dense>
+#include <iostream>
+#include <filesystem>
+
+struct Point3Di
+{
+    Eigen::Vector3d point;
+    double timestamp;
+    float intensity;
+};
+
+struct Point3Dil
+{
+    Eigen::Vector3d point;
+    double timestamp;
+    float intensity;
+    int livoxId;
+};
+
+std::vector<Point3Dil> load_point_cloud(const std::string& lazFile, bool ommit_points_with_timestamp_equals_zero)
+{
+    std::vector<Point3Dil> points;
+    laszip_POINTER laszip_reader;
+    if (laszip_create(&laszip_reader))
+    {
+        fprintf(stderr, "DLL ERROR: creating laszip reader\n");
+        std::abort();
+    }
+
+    laszip_BOOL is_compressed = 0;
+    if (laszip_open_reader(laszip_reader, lazFile.c_str(), &is_compressed))
+    {
+        fprintf(stderr, "DLL ERROR: opening laszip reader for '%s'\n", lazFile.c_str());
+        std::abort();
+    }
+    std::cout << "compressed : " << is_compressed << std::endl;
+    laszip_header* header;
+
+    if (laszip_get_header_pointer(laszip_reader, &header))
+    {
+        fprintf(stderr, "DLL ERROR: getting header pointer from laszip reader\n");
+        std::abort();
+    }
+    fprintf(stderr, "file '%s' contains %u points\n", lazFile.c_str(), header->number_of_point_records);
+    laszip_point* point;
+    if (laszip_get_point_pointer(laszip_reader, &point))
+    {
+        fprintf(stderr, "DLL ERROR: getting point pointer from laszip reader\n");
+        std::abort();
+    }
+
+    int counter_ts0 = 0;
+    int counter_filtered_points = 0;
+    for (laszip_U32 j = 0; j < header->number_of_point_records; j++)
+    {
+        if (laszip_read_point(laszip_reader))
+        {
+            fprintf(stderr, "DLL ERROR: reading point %u\n", j);
+            laszip_close_reader(laszip_reader);
+            return points;
+            //std::abort();
+        }
+        Point3Dil p;
+
+        double cal_x = 11.0 / 1000.0; // ToDo change if lidar differen than livox mid 360
+        double cal_y = 23.29 / 1000.0;
+        double cal_z = -44.12 / 1000.0;
+
+        Eigen::Vector3d pf(header->x_offset + header->x_scale_factor * static_cast<double>(point->X), header->y_offset + header->y_scale_factor * static_cast<double>(point->Y), header->z_offset + header->z_scale_factor * static_cast<double>(point->Z));
+        p.point.x() = pf.x() - cal_x;
+        p.point.y() = pf.y() - cal_y;
+        p.point.z() = pf.z() - cal_z;
+        p.timestamp = point->gps_time;
+        p.intensity = point->intensity;
+        p.livoxId = point->user_data;
+
+        if (p.timestamp == 0 && ommit_points_with_timestamp_equals_zero)
+        {
+            counter_ts0++;
+        }
+        else
+        {
+             points.emplace_back(p);
+        }
+    }
+
+    std::cout << "number points with ts == 0: " << counter_ts0 << std::endl;
+    std::cout << "counter_filtered_points: " << counter_filtered_points << std::endl;
+    std::cout << "total number points: " << points.size() << std::endl;
+    laszip_close_reader(laszip_reader);
+    return points;
+}
+bool saveLaz(const std::string& filename, const std::vector<Point3Di>& points_global)
+{
+
+    constexpr float scale = 0.0001f; // one tenth of milimeter
+    // find max
+    double max_x{ std::numeric_limits<double>::lowest() };
+    double max_y{ std::numeric_limits<double>::lowest() };
+    double max_z{ std::numeric_limits<double>::lowest() };
+    double min_x = 1000000000000.0;
+    double min_y = 1000000000000.0;
+    double min_z = 1000000000000.0;
+
+    for (auto& p : points_global)
+    {
+        if (p.point.x() < min_x)
+        {
+            min_x = p.point.x();
+        }
+        if (p.point.x() > max_x)
+        {
+            max_x = p.point.x();
+        }
+
+        if (p.point.y() < min_y)
+        {
+            min_y = p.point.y();
+        }
+        if (p.point.y() > max_y)
+        {
+            max_y = p.point.y();
+        }
+
+        if (p.point.z() < min_z)
+        {
+            min_z = p.point.z();
+        }
+        if (p.point.z() > max_z)
+        {
+            max_z = p.point.z();
+        }
+    }
+
+    std::cout << "processing: " << filename << "points " << points_global.size() << std::endl;
+
+    laszip_POINTER laszip_writer;
+    if (laszip_create(&laszip_writer))
+    {
+        fprintf(stderr, "DLL ERROR: creating laszip writer\n");
+        return false;
+    }
+
+    // get a pointer to the header of the writer so we can populate it
+
+    laszip_header* header;
+
+    if (laszip_get_header_pointer(laszip_writer, &header))
+    {
+        fprintf(stderr, "DLL ERROR: getting header pointer from laszip writer\n");
+        return false;
+    }
+
+    // populate the header
+
+    header->file_source_ID = 4711;
+    header->global_encoding = (1 << 0); // see LAS specification for details
+    header->version_major = 1;
+    header->version_minor = 2;
+    //    header->file_creation_day = 120;
+    //    header->file_creation_year = 2013;
+    header->point_data_format = 1;
+    header->point_data_record_length = 0;
+    header->number_of_point_records = points_global.size();
+    header->number_of_points_by_return[0] = points_global.size();
+    header->number_of_points_by_return[1] = 0;
+    header->point_data_record_length = 28;
+    header->x_scale_factor = scale;
+    header->y_scale_factor = scale;
+    header->z_scale_factor = scale;
+
+    header->max_x = max_x;
+    header->min_x = min_x;
+    header->max_y = max_y;
+    header->min_y = min_y;
+    header->max_z = max_z;
+    header->min_z = min_z;
+
+    // optional: use the bounding box and the scale factor to create a "good" offset
+    // open the writer
+    laszip_BOOL compress = (strstr(filename.c_str(), ".laz") != 0);
+
+    if (laszip_open_writer(laszip_writer, filename.c_str(), compress))
+    {
+        fprintf(stderr, "DLL ERROR: opening laszip writer for '%s'\n", filename.c_str());
+        return false;
+    }
+
+    fprintf(stderr, "writing file '%s' %scompressed\n", filename.c_str(), (compress ? "" : "un"));
+
+    // get a pointer to the point of the writer that we will populate and write
+
+    laszip_point* point;
+    if (laszip_get_point_pointer(laszip_writer, &point))
+    {
+        fprintf(stderr, "DLL ERROR: getting point pointer from laszip writer\n");
+        return false;
+    }
+
+    laszip_I64 p_count = 0;
+    laszip_F64 coordinates[3];
+
+    for (int i = 0; i < points_global.size(); i++)
+    {
+        const auto& p = points_global[i];
+        point->intensity = p.intensity;
+        point->gps_time = p.timestamp * 1e9;
+        // std::cout << p.timestamp << std::endl;
+        //  point->user_data = 0;//p.line_id;
+        //  point->classification = p.point.tag;
+        p_count++;
+        coordinates[0] = p.point.x();
+        coordinates[1] = p.point.y();
+        coordinates[2] = p.point.z();
+        if (laszip_set_coordinates(laszip_writer, coordinates))
+        {
+            fprintf(stderr, "DLL ERROR: setting coordinates for point %I64d\n", p_count);
+            return false;
+        }
+
+        if (laszip_write_point(laszip_writer))
+        {
+            fprintf(stderr, "DLL ERROR: writing point %I64d\n", p_count);
+            return false;
+        }
+    }
+
+    if (laszip_get_point_count(laszip_writer, &p_count))
+    {
+        fprintf(stderr, "DLL ERROR: getting point count\n");
+        return false;
+    }
+
+    fprintf(stderr, "successfully written %I64d points\n", p_count);
+
+    // close the writer
+
+    if (laszip_close_writer(laszip_writer))
+    {
+        fprintf(stderr, "DLL ERROR: closing laszip writer\n");
+        return false;
+    }
+
+    // destroy the writer
+
+    if (laszip_destroy(laszip_writer))
+    {
+        fprintf(stderr, "DLL ERROR: destroying laszip writer\n");
+        return false;
+    }
+
+    std::cout << "exportLaz DONE" << std::endl;
+    return true;
+}
+
+
+std::unordered_map<int, std::string> GetIdToStringMapping(const std::string& filename)
+{
+    std::unordered_map<int, std::string> dataMap;
+    std::ifstream fst(filename);
+    std::string line;
+    while (std::getline(fst, line)) {
+        std::istringstream iss(line);
+        int key;
+        std::string value;
+
+        if (iss >> key >> value) {
+            dataMap[key] = value;
+        }
+        else {
+            std::cerr << "Failed to parse line: " << line << std::endl;
+        }
+    }
+    return dataMap;
+}
+
+
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> arguments;
+    for (int i = 1; i < argc; i++) {
+        arguments.push_back(argv[i]);
+    }
+    if (arguments.size() != 2) {
+        std::cout << "Usage \n";
+        std::cout << " " << argv[0] << "<input_file_from_mandaye> <output>\n";
+        return 0;
+    }
+    const std::filesystem::path inputLazFile{ arguments[0]};
+    const std::filesystem::path inputSnFile = inputLazFile.parent_path()/inputLazFile.stem().concat(".sn");
+    const std::filesystem::path outputFile{ arguments[1] };
+    std::cout << "Input Laz file " << inputLazFile << std::endl;
+    std::cout << "Input Sn file " << inputSnFile << std::endl;
+
+    if (!std::filesystem::exists(inputLazFile))
+    {
+        std::cout << "No input file " << inputLazFile << std::endl;
+    }
+    if (!std::filesystem::exists(inputSnFile))
+    {
+        std::cout << "No input file " << inputSnFile << std::endl;
+    }
+
+    const auto mapping = GetIdToStringMapping(inputSnFile.string());
+
+    const auto data = load_point_cloud(inputLazFile.string(), true);
+
+    std::unordered_map<int, std::vector<Point3Di>> data_separated;
+
+    for (const auto& pInput : data)
+    {
+        const int id = pInput.livoxId;
+
+        Point3Di pOutput;
+        pOutput.point = pInput.point;
+        pOutput.intensity = pInput.intensity;
+        pOutput.timestamp = pInput.timestamp;
+        data_separated[id].push_back(pOutput);
+    }
+
+    for (const auto& [id, sn] : mapping)
+    {
+        const std::filesystem::path outputFileSn = outputFile.parent_path() / outputFile.stem().concat("_" + sn + ".laz");
+        const auto& lidarData = data_separated[id];
+        saveLaz(outputFileSn.string(), lidarData);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Multilivox support. Should be compatible with older version of mandeye controller.

Sample calibration file:
```json
{
    "calibration": {
        "47MDL9T0020193": {
           "identity" : "true"
        },
        "47MDL9S0020300":
        {
            "order" : "ROW",
            "inverted" : "TRUE",
            "data":[
                0.999824, 0.00466397, -0.0181595, -0.00425984,
                -0.0181478, -0.00254457, -0.999832, -0.151599,
                -0.0047094,0.999986, -0.00245948, -0.146408,
                0, 0, 0, 1
            ]
        } 
    },
    "imuToUse": "47MDL9T0020193"
}
```