### PR TITLE
Fix no points loading

### DIFF
--- a/src/lidar_odometry.cpp
+++ b/src/lidar_odometry.cpp
@@ -402,7 +402,7 @@ void lidar_odometry_gui()
                     std::cout << "poses.size(): " << poses.size() << std::endl;
 
                     if (poses.size() == 0) {
-                        std::cerr << "Loading points went wrong! Could not load points!" << std::endl;
+                        std::cerr << "Loading poses went wrong! Could not load poses!" << std::endl;
                         return;
                     }
 

--- a/src/lidar_odometry.cpp
+++ b/src/lidar_odometry.cpp
@@ -401,7 +401,7 @@ void lidar_odometry_gui()
 
                     std::cout << "poses.size(): " << poses.size() << std::endl;
 
-                    if (poses.size() == 0) {
+                    if (poses.empty()) {
                         std::cerr << "Loading poses went wrong! Could not load poses!" << std::endl;
                         return;
                     }

--- a/src/lidar_odometry.cpp
+++ b/src/lidar_odometry.cpp
@@ -401,6 +401,11 @@ void lidar_odometry_gui()
 
                     std::cout << "poses.size(): " << poses.size() << std::endl;
 
+                    if (poses.size() == 0) {
+                        std::cerr << "Loading points went wrong! Could not load points!" << std::endl;
+                        return;
+                    }
+
                     int thershold = 20;
                     WorkerData wd;
                     // std::vector<double> temp_ts;


### PR DESCRIPTION
Lidar odometry does not recognizes if points are loaded correctly.
This change prevents segmentation fault caused by wrong loaded data,