### PR TITLE
Step 1 optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ add_subdirectory(core_hd_mapping)
 set(CORE_LIBRARIES core core-hd-mapping)
 set(GUI_LIBRARIES imgui imguizmo)
 
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 add_subdirectory(apps/hd_mapper)
 add_subdirectory(apps/lidar_odometry_step_1)
 add_subdirectory(apps/manual_color)

--- a/apps/lidar_odometry_step_1/lidar_odometry.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry.cpp
@@ -324,16 +324,16 @@ void lidar_odometry_gui()
                                        auto calibration = MLvxCalib::CombineIntoCalibration(idToSn, preloadedCalibration);
                                        auto data = load_point_cloud(fn.c_str(), true, params.filter_threshold_xy, calibration);
 
-                                       if (fn == laz_files.front())
-                                       {
-                                           fs::path calibrationValidtationFile = wdp / "calibrationValidation.asc";
+                                    //    if (fn == laz_files.front())
+                                    //    {
+                                    //        fs::path calibrationValidtationFile = wdp / "calibrationValidation.asc";
 
-                                           std::ofstream testPointcloud{calibrationValidtationFile.c_str()};
-                                           for (const auto &p : data)
-                                           {
-                                               testPointcloud << p.point.x() << "\t" << p.point.y() << "\t" << p.point.z() << "\t" << p.intensity << "\t" << (int)p.lidarid << "\n";
-                                           }
-                                       }
+                                    //        std::ofstream testPointcloud{calibrationValidtationFile.c_str()};
+                                    //        for (const auto &p : data)
+                                    //        {
+                                    //            testPointcloud << p.point.x() << "\t" << p.point.y() << "\t" << p.point.z() << "\t" << p.intensity << "\t" << (int)p.lidarid << "\n";
+                                    //        }
+                                    //    }
 
                                        std::unique_lock lck(mtx);
                                        for (const auto &[id, calib] : calibration)
@@ -449,121 +449,79 @@ void lidar_odometry_gui()
                     }
 
                     int thershold = 20;
-                    WorkerData wd;
                     // std::vector<double> temp_ts;
                     // temp_ts.reserve(1000000);
 
                     // int last_point = 0;
                     int index_begin = 0;
 
-                    for (size_t i = 0; i < poses.size(); i++)
+                    int n_iter = (int)(poses.size() / thershold);
+                    worker_data.reserve(n_iter);
+                    for (int i = 0; i < n_iter; i++)
                     {
-                        if (i % 1000 == 0)
+                        if (i % 50 == 0)
                         {
                             std::cout << "preparing data " << i + 1 << " of " << poses.size() << std::endl;
                         }
-                        wd.intermediate_trajectory.emplace_back(poses[i]);
-                        wd.intermediate_trajectory_motion_model.emplace_back(poses[i]);
-                        wd.intermediate_trajectory_timestamps.emplace_back(timestamps[i]);
-
-                        //
-                        TaitBryanPose tb = pose_tait_bryan_from_affine_matrix(poses[i]);
-                        // wd.imu_roll_pitch.emplace_back(tb.om, tb.fi);
-                        wd.imu_om_fi_ka.emplace_back(tb.om, tb.fi, tb.ka);
-
-                        // temp_ts.emplace_back(timestamps[i]);
-
-                        if (wd.intermediate_trajectory.size() >= thershold)
+                        WorkerData wd;
+                        wd.intermediate_trajectory.reserve(thershold);
+                        wd.intermediate_trajectory_motion_model.reserve(thershold);
+                        wd.intermediate_trajectory_timestamps.reserve(thershold);
+                        wd.imu_om_fi_ka.reserve(thershold);
+                        for (int ii = 0; ii < thershold; ii++)
                         {
-                            /*auto index_lower = std::lower_bound(points.begin(), points.end(), wd.intermediate_trajectory_timestamps[0],
-                                                                [](Point3Di lhs, double rhs) -> bool
-                                                                { return lhs.timestamp < rhs; });
-                            unsigned long long int i_begin = std::distance(points.begin(), index_lower);
-
-                            auto index_upper = std::lower_bound(points.begin(), points.end(), wd.intermediate_trajectory_timestamps[wd.intermediate_trajectory_timestamps.size() - 1],
-                                                                [](Point3Di lhs, double rhs) -> bool
-                                                                { return lhs.timestamp < rhs; });
-                            unsigned long long int i_end = std::distance(points.begin(), index_upper);*/
-
-                            std::vector<Point3Di> points;
-                            // for (const auto &pp : pointsPerFile)
-                            //{
-                            //     for (const auto &p : pp)
-                            //     {
-                            //         if (p.timestamp >= wd.intermediate_trajectory_timestamps[0] && p.timestamp <= wd.intermediate_trajectory_timestamps[wd.intermediate_trajectory_timestamps.size() - 1]){
-                            //             points.push_back(p);
-                            //         }
-                            //     }
-                            // }
-                            bool found = false;
-
-                            for (int index = index_begin; index < pointsPerFile.size(); index++)
-                            {
-                                for (const auto &p : pointsPerFile[index])
-                                {
-                                    if (p.timestamp >= wd.intermediate_trajectory_timestamps[0].first && p.timestamp <= wd.intermediate_trajectory_timestamps[wd.intermediate_trajectory_timestamps.size() - 1].first)
-                                    {
-                                        points.push_back(p);
-                                    }
-                                    if (p.timestamp >= wd.intermediate_trajectory_timestamps[0].first && !found)
-                                    {
-                                        index_begin = index;
-                                        found = true;
-                                    }
-                                    if (p.timestamp > wd.intermediate_trajectory_timestamps[wd.intermediate_trajectory_timestamps.size() - 1].first)
-                                    {
-                                        break;
-                                    }
-                                }
-                            }
-
-                            // for (unsigned long long int k = i_begin; k < i_end; k++)
-                            // if (i % 1000 == 0)
-                            //{
-                            // std::cout << "points.size() " << points.size() << std::endl;
-                            //}
-
-                            for (unsigned long long int k = 0; k < points.size(); k++)
-                            {
-                                // if (points[k].timestamp > wd.intermediate_trajectory_timestamps[0] && points[k].timestamp < wd.intermediate_trajectory_timestamps[wd.intermediate_trajectory_timestamps.size() - 1])
-                                //{
-                                auto p = points[k];
-                                auto lower = std::lower_bound(wd.intermediate_trajectory_timestamps.begin(), wd.intermediate_trajectory_timestamps.end(), p.timestamp,
-                                                              [](std::pair<double, double> lhs, double rhs) -> bool
-                                                              { return lhs.first < rhs; });
-
-                                p.index_pose = std::distance(wd.intermediate_trajectory_timestamps.begin(), lower);
-                                wd.intermediate_points.emplace_back(p);
-                                wd.original_points.emplace_back(p);
-                                //}
-                            }
-
-                            if (params.decimation > 0.0)
-                            {
-                                wd.intermediate_points = decimate(wd.intermediate_points, params.decimation, params.decimation, params.decimation);
-                            }
-
-                            worker_data.push_back(wd);
-                            wd.intermediate_points.clear();
-                            wd.original_points.clear();
-                            wd.intermediate_trajectory.clear();
-                            wd.intermediate_trajectory_motion_model.clear();
-                            wd.intermediate_trajectory_timestamps.clear();
-                            // wd.imu_roll_pitch.clear();
-                            wd.imu_om_fi_ka.clear();
-
-                            wd.intermediate_points.reserve(1000000);
-                            wd.original_points.reserve(1000000);
-                            wd.intermediate_trajectory.reserve(1000);
-                            wd.intermediate_trajectory_motion_model.reserve(1000);
-                            wd.intermediate_trajectory_timestamps.reserve(1000);
-                            // wd.imu_roll_pitch.reserve(1000);
-                            wd.imu_om_fi_ka.reserve(1000);
-
-                            // temp_ts.clear();
+                            int idx = i * thershold + ii;
+                            wd.intermediate_trajectory.emplace_back(poses[idx]);
+                            wd.intermediate_trajectory_motion_model.emplace_back(poses[idx]);
+                            wd.intermediate_trajectory_timestamps.emplace_back(timestamps[idx]);
+                            TaitBryanPose tb = pose_tait_bryan_from_affine_matrix(poses[idx]);
+                            // wd.imu_roll_pitch.emplace_back(tb.om, tb.fi);
+                            wd.imu_om_fi_ka.emplace_back(tb.om, tb.fi, tb.ka);
                         }
-                    }
+                        std::vector<Point3Di> points;
+                        bool found = false;
+                        auto lower = pointsPerFile[0].begin();
+                        for (int index = index_begin; index < pointsPerFile.size(); index++)
+                        {
+                            auto lower = std::lower_bound(
+                                pointsPerFile[index].begin(), pointsPerFile[index].end(), 
+                                wd.intermediate_trajectory_timestamps[0].first, 
+                                [](const Point3Di &point, double timestamp) {
+                                    return point.timestamp < timestamp;
+                                });
+                            auto upper = std::upper_bound(
+                                pointsPerFile[index].begin(), pointsPerFile[index].end(), 
+                                wd.intermediate_trajectory_timestamps[wd.intermediate_trajectory_timestamps.size() - 1].first, 
+                                [](double timestamp, const Point3Di &point) {
+                                    return timestamp < point.timestamp;
+                                });
+                            auto tmp = std::distance(lower, upper);
+                            points.reserve(points.size() + std::distance(lower, upper));
+                            if (lower != upper) {
+                                points.insert(points.end(), std::make_move_iterator(lower), std::make_move_iterator(upper));
+                                // std::cout << "Got points in timestamp range: " << points.size() << std::endl;
+                                found = true;
+                            }   
+                        }
 
+                        wd.original_points = points;
+                        for (unsigned long long int k = 0; k < wd.original_points.size(); k++)
+                        {
+                            Point3Di& p = wd.original_points[k];
+                            auto lower = std::lower_bound(wd.intermediate_trajectory_timestamps.begin(), wd.intermediate_trajectory_timestamps.end(), p.timestamp,
+                                                            [](std::pair<double, double> lhs, double rhs) -> bool
+                                                            { return lhs.first < rhs; });
+                            p.index_pose = std::distance(wd.intermediate_trajectory_timestamps.begin(), lower);
+                        }
+                
+                        if (params.decimation > 0.0)
+                        {            
+                            wd.intermediate_points = decimate(wd.original_points, params.decimation, params.decimation, params.decimation);
+                            
+                        }
+                        worker_data.push_back(wd);
+                    }
+                    
                     params.m_g = worker_data[0].intermediate_trajectory[0];
                     step_1_done = true;
                     std::cout << "step_1_done please click 'compute_all (step 2)' to continue calculations" << std::endl;


### PR DESCRIPTION
# Pull request - step 1 optimization

Hello. I came to notice that there are a several things that might be better done in data loading process. I am not a big C++ expert, so I recommend a double-check and be available also to discuss these changes in more details. If you tell me on which datasets I should test, I can do that also.

1) The main thing I checked was the time filtering of the point cloud to split it to different worker data. I pre-filter the points by timestamp and then use logarithmic lower/upper bound functions to locate the range of points to use for filtering. The resulting time measurements (of course, very HW and system-dependent but clearly having order of magnitude difference) are below. Note that sorting does not seem to have a major overhead compared to the gained speed at filtering. Faster search algorithm (if timestamps are represented as integer nanoseconds) can be considered. 

* Elapsed time reading: 130874ms (original code)
* Elapsed time reading: 154925ms (with sorting)

* Elapsed time timestamp filtering: 172041ms (original code)
* Elapsed time timestamp filtering: 158ms (applied on sorted points)

I have seen that you have some pretty similar code in the code you commented out. Have you found some situation where proposed solution does not work, or why was it abandoned? 

2) I also commented out writing of `calibrationValidation` file in `lidar_odometry_gui` optional. That makes a huge difference reducing time of reading (lambda function) from 172041ms to 48553ms (including sorting).  The overhead might be small for small files, but once one big laz is used, the overhead is just huge. What if we added some parameter to the interface telling whether to save the calibration validation or not? (I can add it.)

3) There seem to be a bit of a mess with creating `WorkerData`, which always have length of attributes depending on the fixed `threshold` parameter. A lot of memory is constantly cleared and reserved manually for `WorkerData` while this can be dealt with by just changing a bit the whole for-loop and just keeping `WorkerData` inside its scope. The execution of the code dealing with filling of `WorkerData`'s vector then goes from 7307ms to 6265ms. The change is small but consistent between different runs, at least on my computer.

I also noticed that you separate data into different `WorkerData` as if to pass it to multiprocessing, but then just assemble it back to a long vector in e.g. step 2. Is the multiprocessing abandoned? Some issues? No time to implement? Because otherwise I am not sure why to do split-and-merge. It is concerning me as very often I get BSOD at further steps, especially at Consistency. I would happy to check if something can be done there in my free time, if you would be interested.

Best regards,
Valeria

