### PR TITLE
Multi thread determinism fix

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry_gui.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_gui.cpp
@@ -287,7 +287,7 @@ void lidar_odometry_gui()
             ImGui::InputInt("threshold initial points", &params.threshold_initial_points);
             ImGui::Checkbox("save_calibration_validation_file", &params.save_calibration_validation);
             ImGui::InputInt("number of calibration validation points", &params.calibration_validation_points);
-            //ImGui::Checkbox("use_multithread", &params.useMultithread);
+            ImGui::Checkbox("use_multithread", &params.useMultithread);
 
             ImGui::Checkbox("fusionConventionNwu", &params.fusionConventionNwu);
             if (params.fusionConventionNwu)

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.h
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.h
@@ -47,7 +47,7 @@ struct LidarOdometryParams
     bool use_motion_from_previous_step = true;
     double consecutive_distance = 0.0;
     int nr_iter = 100;
-    //bool useMultithread = true;
+    bool useMultithread = true;
     std::vector<Point3Di> reference_points;
     //double decimation = 0.1;
     double decimation = 0.01;


### PR DESCRIPTION
The multi threading is instructed by unsqeunced parallel execution with multiple input and one output. 
The issue with this approach is that hessian matrix element are summed in random order.

It can cause minor numerical instability, that will affect results.

To regain the detarminism I propose:
- compute contribution to Hessian matrix of every observation parallel
- add those sequentially. 

The overhead should be checked.