### PR TITLE
fix save-all-marked-scans-to-laz(as separeate global scans)

### DIFF
--- a/apps/multi_view_tls_registration/multi_view_tls_registration_gui.cpp
+++ b/apps/multi_view_tls_registration/multi_view_tls_registration_gui.cpp
@@ -1004,11 +1004,15 @@ void project_gui()
 
             if (ImGui::Button("save all marked scans to laz (as separate global scans)"))
             {
-                save_separately_to_las(session, ".laz");
+                std::string output_folder_name_separately= "";
+                output_folder_name_separately = mandeye::fd::SelectFolder("Choose folder");
+                save_separately_to_las(session, output_folder_name_separately,".laz");
             }
             if (ImGui::Button("save all marked scans to las (as separate global scans)"))
-            {
-                save_separately_to_las(session, ".las");
+            {   
+                std::string output_folder_name_separately = "";
+                output_folder_name_separately = mandeye::fd::SelectFolder("Choose folder");
+                save_separately_to_las(session, output_folder_name_separately, ".las");
             }
 
             ImGui::Checkbox("is_trajectory_export_downsampling", &tls_registration.is_trajectory_export_downsampling);


### PR DESCRIPTION
Problem:
Previously, there was no variable assigned to store the path of the destination folder. As a result, when attempting to save files, the program tried to write them to an incorrect or non-existent folder, causing the error: DLL ERROR: opening laszip writer for '.laz\lidar0000-mid360fix_processed.las'.

Solution:
A functionality was added allowing the user to choose the folder where the files would be saved. This resolved the issue with the incorrect path, and now the files are correctly saved in the specified directory.