### PR TITLE
Tool for removing calibration from multi-livox session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ add_subdirectory(apps/mandeye_mission_recorder_calibration)
 add_subdirectory(apps/mandeye_single_session_viewer)
 add_subdirectory(apps/livox_mid_360_intrinsic_calibration)
 add_subdirectory(apps/single_session_manual_coloring)
+add_subdirectory(apps/concatenate_multi_livox)
 
 # CPack configuration
 set(CPACK_PACKAGE_NAME "hd_mapping")

--- a/apps/concatenate_multi_livox/CMakeLists.txt
+++ b/apps/concatenate_multi_livox/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.15.0)
+
+project(concatenate_multi_livox)
+
+add_executable(concatenate_multi_livox concatenate_multi_livox.cpp ../lidar_odometry_step_1/lidar_odometry_utils.cpp)
+
+target_include_directories(
+        concatenate_multi_livox
+  PRIVATE include
+          ${REPOSITORY_DIRECTORY}/core/include
+          ${REPOSITORY_DIRECTORY}/core_hd_mapping/include
+          ${EXTERNAL_LIBRARIES_DIRECTORY}
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/glm
+          ${EIGEN3_INCLUDE_DIR}
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/imgui
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/imgui/backends
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/ImGuizmo
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/json/include
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/portable-file-dialogs-master
+          ${LASZIP_INCLUDE_DIR}/LASzip/include
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/glew-2.2.0/include
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/observation_equations/codes
+          ${EXTERNAL_LIBRARIES_DIRECTORY}/Fusion/Fusion
+          ${FREEGLUT_INCLUDE_DIR})
+
+target_link_libraries(concatenate_multi_livox PRIVATE core ${PLATFORM_LASZIP_LIB}
+                                                ${PLATFORM_MISCELLANEOUS_LIBS})
+
+if(WIN32)
+  add_custom_command(
+    TARGET concatenate_multi_livox
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:concatenate_multi_livox>
+            $<TARGET_FILE_DIR:concatenate_multi_livox>
+    COMMAND_EXPAND_LISTS)
+endif()
+
+install (TARGETS concatenate_multi_livox DESTINATION bin)

--- a/apps/concatenate_multi_livox/concatenate_multi_livox.cpp
+++ b/apps/concatenate_multi_livox/concatenate_multi_livox.cpp
@@ -1,0 +1,145 @@
+#include <iostream>
+#include <filesystem>
+#include "../lidar_odometry_step_1/lidar_odometry_utils.h"
+#include "export_laz.h"
+int main(int argc, char *argv[])
+{
+    if (argc < 3)
+    {
+        std::cout << "Usage: " << argv[0] << " <input_dir> <output_dir>" << std::endl;
+        return 1;
+    }
+    const std::string input_dir = argv[1];
+    const std::string output_dir = argv[2];
+    if (!std::filesystem::exists(input_dir))
+    {
+        std::cout << "Input directory does not exist: " << input_dir << std::endl;
+        return 1;
+    }
+
+    std::vector<std::string> laz_files;
+    std::vector<std::string> csv_files;
+    std::vector<std::string> sn_files;
+    std::vector<std::string> all_file_names;
+    for (const auto &entry : std::filesystem::directory_iterator(input_dir))
+    {
+        if (entry.is_regular_file())
+        {
+            const std::string filename = entry.path().filename().string();
+            if (filename.ends_with(".laz") || filename.ends_with(".las"))
+            {
+                laz_files.push_back(entry.path().string());
+                all_file_names.push_back(entry.path().string());
+            }
+            else if (filename.ends_with(".csv"))
+            {
+                csv_files.push_back(entry.path().string());
+            }
+            else if (filename.ends_with(".sn"))
+            {
+                sn_files.push_back(entry.path().string());
+            }
+        }
+    }
+    // check if number of laz files is equal to number of csv files and sn files
+    const auto scan_number = laz_files.size();
+    if (scan_number != csv_files.size() || scan_number != sn_files.size()) {
+        std::cerr << "Number of laz files, csv files and sn files is not equal!" << std::endl;
+        std::cerr << "laz files: " << laz_files.size() << std::endl;
+        std::cerr << "csv files: " << csv_files.size() << std::endl;
+        std::cerr << "sn files: " << sn_files.size() << std::endl;
+        return 1;
+    }
+    std::cout << "Found " << scan_number << " scans" << std::endl;
+    // load calibration file
+    const auto calibrationFile = (std::filesystem::path(input_dir) / "calibration.json").string();
+    std::cout << "Loading calibration file: " << calibrationFile << std::endl;
+    auto preloadedCalibration = MLvxCalib::GetCalibrationFromFile(calibrationFile);
+    if (preloadedCalibration.empty()) {
+        std::cerr << "No calibration data found in file: " << calibrationFile << std::endl;
+        std::cerr << "Please check the file format and content." << std::endl;
+        return 1;
+    }
+    std::cout << "Loaded calibration for " << preloadedCalibration.size() << " sensors." << std::endl;
+    for (const auto &[sn, _] : preloadedCalibration) {
+        std::cout << " -> " << sn << std::endl;
+    }
+    // Get Id of Imu to use
+    const std::string imuSnToUse = MLvxCalib::GetImuSnToUse(calibrationFile);
+    if (imuSnToUse.empty()) {
+        std::cerr << "No IMU serial number found in calibration file: " << calibrationFile << std::endl;
+        std::cerr << "Please check the file format and content.";
+        return 1;
+    }
+    std::cout << "IMU to use: " << imuSnToUse << std::endl;
+    // get id to serial number mapping
+
+
+    if (!std::filesystem::exists(output_dir)) {
+        //create output directory if it does not exist
+        std::filesystem::create_directory(output_dir);
+    }
+
+    // sort
+    std::sort(std::begin(laz_files), std::end(laz_files));
+    std::sort(std::begin(csv_files), std::end(csv_files));
+    std::sort(std::begin(sn_files), std::end(sn_files));
+
+
+    // process laz
+    for (int i = 0; i < scan_number; i++){
+        const std::string &laz_file = laz_files[i];
+        const std::string &csv_file = csv_files[i];
+        const std::string &fnSn = sn_files[i];
+
+        const auto imuBaseName = std::filesystem::path(csv_file).filename().string();
+
+        const std::filesystem::path output_path = std::filesystem::path(output_dir) / std::filesystem::path(laz_file).filename();
+        const std::filesystem::path output_path_csv = std::filesystem::path(output_dir) / imuBaseName;
+        std::cout << "Processing LAZ file: " << laz_file << std::endl;
+        // Load mapping from id to sn
+
+        const auto idToSn = MLvxCalib::GetIdToSnMapping(fnSn);
+        const int imuNumberToUse = MLvxCalib::GetImuIdToUse(idToSn, imuSnToUse);
+        const auto calibration = MLvxCalib::CombineIntoCalibration(idToSn, preloadedCalibration);
+        auto data = load_point_cloud(laz_file.c_str(), false, 0, std::numeric_limits<double>::max(), calibration);
+        std::cout << "Loaded " << data.size() << " points from " << laz_file << std::endl;
+
+        std::vector<Eigen::Vector3d> pointcloud;
+        std::vector<unsigned short> intensity;
+        std::vector<double> timestamps;
+        pointcloud.reserve(data.size());
+        intensity.reserve(data.size());
+        timestamps.reserve(data.size());
+        int counter = 0;
+        for (const auto &point : data) {
+            pointcloud.push_back(point.point);
+            intensity.push_back(point.intensity);
+            timestamps.push_back(double(point.timestamp)/1e9);
+        }
+        exportLaz(output_path.string(), pointcloud, intensity, timestamps, 0, 0, 0);
+        std::cout << "Saved processed points to: " << output_path.string() << std::endl;
+
+        // imu
+        auto imu = load_imu(csv_file.c_str(), imuNumberToUse);
+
+        std::ofstream out(output_path_csv.string());
+        if (!out.is_open()) {
+            std::cerr << "Failed to open output file: " << output_path_csv.string() << std::endl;
+            continue;
+        }
+        out << "timestamp timestampUnix accX accY accZ gyroX gyroY gyroZ\n";
+        for (const auto &[timestamp,  gyro, accel] : imu) {
+            out << static_cast<uint64_t>(1e9 * timestamp.first) << " "
+                << static_cast<uint64_t>(1e9 * timestamp.second) << " "
+                << accel.axis.x << " "
+                << accel.axis.y << " "
+                << accel.axis.z << " "
+                << gyro.axis.x << " "
+                << gyro.axis.y << " "
+                << gyro.axis.z << "\n";
+        }
+        std::cout << "Saved IMU data to: " << output_path_csv.string() << std::endl;
+    }
+
+}

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.cpp
@@ -686,10 +686,10 @@ std::vector<std::tuple<std::pair<double, double>, FusionVector, FusionVector>> l
     if (hasTsColumn)
     {
         is_legacy = false;
-        if (!hasAccsColumns && !hasGyrosColumns)
+        if (!hasAccsColumns && !hasGyrosColumns && !hasUnixTimestampColumn)
         {
             std::cerr << "Input csv file is missing one of the mandatory columns :\n";
-            std::cerr << "timestamp,gyroX,gyroY,gyroZ,accX,accY,accZ";
+            std::cerr << "timestamp,timestampUnix,gyroX,gyroY,gyroZ,accX,accY,accZ";
             return all_data;
         }
     }

--- a/apps/mandeye_raw_data_viewer/mandeye_raw_data_viewer.cpp
+++ b/apps/mandeye_raw_data_viewer/mandeye_raw_data_viewer.cpp
@@ -255,7 +255,7 @@ void project_gui()
                         sn_files.push_back(fileName);
                     } });
 
-                if (input_file_names.size() > 0 && laz_files.size() == csv_files.size() && laz_files.size() == sn_files.size())
+                if (input_file_names.size() > 0 && laz_files.size() == csv_files.size())
                 {
                     working_directory = fs::path(input_file_names[0]).parent_path().string();
 


### PR DESCRIPTION
This tool flatten multi-livox datasets to that which has no calibration.

Usage:
```bash
concatenate_multi_livox continousScanning_0066 continousScanning_0066_concat
```

Next this dataset can be used with tool like https://github.com/michalpelka/mandeye_to_bag

On Ubuntu 20.04 with ROS Noetic you can genearate classical bag: 
```shell
rosrun mandeye_to_rosbag1 mandeye_to_rosbag 'continousScanning_0066_concat' 'continousScanning_0066_concat.bag' --lines 1 
```

Next bag can be tested with Fast LIO (https://github.com/michalpelka/FAST_LIO/tree/livox_sdk2):
````
roslaunch fast_lio mapping_avia.launch 
````
and 
```
rosbag play continousScanning_0066_concat.bag
```

<img width="3840" height="2160" alt="Screenshot from 2025-08-15 22-46-00" src="https://github.com/user-attachments/assets/530008a9-b071-44ba-9075-8eb0e17d457b" />

Flatten dataset:
https://drive.google.com/file/d/1JeXSWf7wCHr3fV4ZPIM1-ZrkL9I8fid9/view?usp=sharing

Rosbag for Fast-LIO:
https://drive.google.com/file/d/1cVAl9XpQF5rrZ32KoNuBpOauezBH9XsC/view?usp=drive_link