### PR TITLE
Overall lidar_odometry_step_1 improvements and bugfixes:

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry.cpp
@@ -922,7 +922,7 @@ std::vector<WorkerData> run_lidar_odometry(std::string input_dir, LidarOdometryP
     }
     std::vector<std::vector<Point3Di>> pointsPerFile;
     Imu imu_data;
-    if (!load_data(input_file_names, params, pointsPerFile, imu_data, TRUE))
+    if (!load_data(input_file_names, params, pointsPerFile, imu_data, true))
     {
         std::cout << "Calculation failed at data loading, exiting." << std::endl;
         return worker_data;
@@ -941,7 +941,7 @@ std::vector<WorkerData> run_lidar_odometry(std::string input_dir, LidarOdometryP
 
     std::atomic<float> loProgress;
 
-    if (!compute_step_2(worker_data, params, ts_failure, loProgress, pause, TRUE))
+    if (!compute_step_2(worker_data, params, ts_failure, loProgress, pause, true))
     {
         std::cout << "Calculation failed at step 2 of lidar odometry, exiting." << std::endl;
         return worker_data;

--- a/apps/lidar_odometry_step_1/lidar_odometry.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry.cpp
@@ -928,7 +928,7 @@ std::vector<WorkerData> run_lidar_odometry(std::string input_dir, LidarOdometryP
         return worker_data;
     }
     Trajectory trajectory;
-    calculate_trajectory(trajectory, imu_data, params.fusionConventionNwu, params.fusionConventionEnu, params.fusionConventionNed, params.ahrs_gain, TRUE);
+    calculate_trajectory(trajectory, imu_data, params.fusionConventionNwu, params.fusionConventionEnu, params.fusionConventionNed, params.ahrs_gain, true);
 
     std::atomic<bool> pause{false};
 

--- a/apps/lidar_odometry_step_1/lidar_odometry.h
+++ b/apps/lidar_odometry_step_1/lidar_odometry.h
@@ -16,9 +16,9 @@
 using Trajectory = std::map<double, std::pair<Eigen::Matrix4d, double>>;
 using Imu = std::vector<std::tuple<std::pair<double, double>, FusionVector, FusionVector>>;
 
-bool load_data(std::vector<std::string>& input_file_names, LidarOdometryParams& params, std::vector<std::vector<Point3Di>>& pointsPerFile, Imu& imu_data);
+bool load_data(std::vector<std::string>& input_file_names, LidarOdometryParams& params, std::vector<std::vector<Point3Di>>& pointsPerFile, Imu& imu_data, bool debugMsg);
 void calculate_trajectory(
-    Trajectory& trajectory, Imu& imu_data, bool fusionConventionNwu, bool fusionConventionEnu, bool fusionConventionNed, double ahrs_gain);
+    Trajectory& trajectory, Imu& imu_data, bool fusionConventionNwu, bool fusionConventionEnu, bool fusionConventionNed, double ahrs_gain, bool debugMsg);
 bool compute_step_1(
     std::vector<std::vector<Point3Di>> &pointsPerFile, LidarOdometryParams &params,
     Trajectory &trajectory, std::vector<WorkerData> &worker_data, const std::atomic<bool> &pause);

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.cpp
@@ -443,7 +443,7 @@ std::vector<Point3Di> load_point_cloud(const std::string &lazFile, bool ommit_po
         fprintf(stderr, "DLL ERROR: opening laszip reader for '%s'\n", lazFile.c_str());
         std::abort();
     }
-    std::cout << "compressed : " << is_compressed << std::endl;
+    //std::cout << "compressed : " << is_compressed << std::endl;
     laszip_header *header;
 
     if (laszip_get_header_pointer(laszip_reader, &header))
@@ -451,7 +451,7 @@ std::vector<Point3Di> load_point_cloud(const std::string &lazFile, bool ommit_po
         fprintf(stderr, "DLL ERROR: getting header pointer from laszip reader\n");
         std::abort();
     }
-    fprintf(stderr, "file '%s' contains %u points\n", lazFile.c_str(), header->number_of_point_records);
+    //fprintf(stderr, "file '%s' contains %u points\n", lazFile.c_str(), header->number_of_point_records);
     laszip_point *point;
     if (laszip_get_point_pointer(laszip_reader, &point))
     {
@@ -461,8 +461,6 @@ std::vector<Point3Di> load_point_cloud(const std::string &lazFile, bool ommit_po
 
     int counter_ts0 = 0;
     int counter_filtered_points = 0;
-
-    std::cout << "header->number_of_point_records:  " << header->number_of_point_records << std::endl;
 
     for (laszip_U32 j = 0; j < header->number_of_point_records; j++)
     {
@@ -540,9 +538,14 @@ std::vector<Point3Di> load_point_cloud(const std::string &lazFile, bool ommit_po
             }
         }
     }
-    std::cout << "number points with ts == 0: " << counter_ts0 << std::endl;
-    std::cout << "counter_filtered_points: " << counter_filtered_points << std::endl;
-    std::cout << "total number points: " << points.size() << std::endl;
+
+    std::cout << header->number_of_point_records << " - " << counter_filtered_points << " = " << points.size();
+    if (counter_ts0 > 0)
+    {
+        std::cout << " (points with 0 timestamp: " << counter_ts0 << ")";
+    }
+    std::cout << std::endl;
+
     laszip_close_reader(laszip_reader);
     return points;
 }
@@ -593,12 +596,12 @@ std::unordered_map<std::string, Eigen::Affine3d> MLvxCalib::GetCalibrationFromFi
     {
         const std::string &lidarSn = calibrationEntry.key();
         Eigen::Matrix4d value;
-        std::cout << "lidarSn : " << lidarSn << std::endl;
+        //std::cout << "lidarSn : " << lidarSn << std::endl;
 
         if (calibrationEntry.value().contains("identity"))
         {
             std::string identity = calibrationEntry.value()["identity"].get<std::string>();
-            std::cout << "identity : " << identity << std::endl;
+            //std::cout << "identity : " << identity << std::endl;
             std::transform(identity.begin(), identity.end(), identity.begin(), ::toupper);
             if (identity == "TRUE")
             {
@@ -623,7 +626,7 @@ std::unordered_map<std::string, Eigen::Affine3d> MLvxCalib::GetCalibrationFromFi
         if (calibrationEntry.value().contains("order"))
         {
             std::string order = calibrationEntry.value()["order"].get<std::string>();
-            std::cout << "order : " << order << std::endl;
+            //std::cout << "order : " << order << std::endl;
             std::transform(order.begin(), order.end(), order.begin(), ::toupper);
             if (order == "COLUMN")
             {
@@ -635,7 +638,7 @@ std::unordered_map<std::string, Eigen::Affine3d> MLvxCalib::GetCalibrationFromFi
         if (calibrationEntry.value().contains("inverted"))
         {
             std::string inverted = calibrationEntry.value()["inverted"].get<std::string>();
-            std::cout << "inverted : " << inverted << std::endl;
+            //std::cout << "inverted : " << inverted << std::endl;
             std::transform(inverted.begin(), inverted.end(), inverted.begin(), ::toupper);
             if (inverted == "TRUE")
             {
@@ -646,8 +649,8 @@ std::unordered_map<std::string, Eigen::Affine3d> MLvxCalib::GetCalibrationFromFi
 
         Eigen::IOFormat HeavyFmt(Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
 
-        std::cout << "Calibration for " << lidarSn << std::endl;
-        std::cout << value.format(HeavyFmt) << std::endl;
+        //std::cout << "Calibration for " << lidarSn << std::endl;
+        //std::cout << value.format(HeavyFmt) << std::endl;
         // Insert into the map
         dataMap[lidarSn] = value;
     }

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.h
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.h
@@ -214,7 +214,7 @@ void align_to_reference(NDT::GridParameters &rgd_params, std::vector<Point3Di> &
 // this function apply correction to pitch and roll
 // void fix_ptch_roll(std::vector<WorkerData> &worker_data);
 
-bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &params, double &ts_failure, std::atomic<float> &loProgress, const std::atomic<bool> &pause);
+bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &params, double &ts_failure, std::atomic<float> &loProgress, const std::atomic<bool> &pause, bool debugMsg);
 void compute_step_2_fast_forward_motion(std::vector<WorkerData> &worker_data, LidarOdometryParams &params);
 
 // for reconstructing worker data from step 1 output

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp
@@ -1930,7 +1930,7 @@ void align_to_reference(NDT::GridParameters &rgd_params, std::vector<Point3Di> &
 }
 
 //extern nglobals::icpProgress.store((float)i / globals::registeredFrames.size());
-bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &params, double &ts_failure, std::atomic<float> &loProgress, const std::atomic<bool> &pause)
+bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &params, double &ts_failure, std::atomic<float> &loProgress, const std::atomic<bool> &pause, bool debugMsg)
 {
     //exit(1);
     bool debug = false;
@@ -1938,7 +1938,6 @@ bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &p
 
     if (worker_data.size() != 0)
     {
-
         std::chrono::time_point<std::chrono::system_clock> start, end;
         start = std::chrono::system_clock::now();
         double acc_distance = 0.0;
@@ -2190,13 +2189,17 @@ bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &p
                 if (delta < 1e-12)
                 {
                     std::cout << "------------" << std::endl;
-                    std::cout << "finished at iteration: " << iter + 1 << " nr_iter: " << params.nr_iter << " delta: " << delta << std::endl;
+                    std::cout << "finished at iteration " << iter + 1 << "/" << params.nr_iter << ", delta: " << delta << std::endl;
                     break;
                 }
 
                 if (iter % 10 == 0 && iter > 0)
                 {
-                    std::cout << "lm_factor " << lm_factor << " delta " << delta << std::endl;
+                    if (debugMsg)
+                    {
+                        std::cout << "lm_factor " << lm_factor << ", delta " << delta << std::endl;
+                    }
+
                     lm_factor *= 10.0;
                 }
 
@@ -2208,15 +2211,18 @@ bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &p
                 }
             }
 
+            end1 = std::chrono::system_clock::now();
+
+            std::chrono::duration<double> elapsed_seconds1 = end1 - start1;
+            std::cout << "optimizing worker_data " << i + 1 << "/" << worker_data.size()
+                << " with acc_distance " << fixed << std::setprecision(1) << acc_distance
+                << "[m] in " << fixed << std::setprecision(2) << elapsed_seconds1.count() << "[s].";
             if (delta > 1e-12)
             {
-                std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
-                std::cout << "finished with delta: " << delta << std::endl;
+                std::cout << " finished with delta: " << std::setprecision(10) << delta << "!!!";
             }
 
-            end1 = std::chrono::system_clock::now();
-            std::chrono::duration<double> elapsed_seconds1 = end1 - start1;
-            std::cout << "optimizing worker_data [" << i + 1 << "] of " << worker_data.size() << " acc_distance: " << acc_distance << " elapsed time: " << elapsed_seconds1.count() << std::endl;
+            std::cout << "\n";
 
             loProgress.store((float)(i + 1) / worker_data.size());
 
@@ -2239,7 +2245,7 @@ bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &p
                                 .translation()
                                 .norm();
 
-            if (!(acc_distance == acc_distance))
+			if (!(acc_distance == acc_distance)) //NaN check
             {
                 worker_data[i].intermediate_trajectory = tmp_worker_data;
                 std::cout << "CHALLENGING DATA OCCURED!!!" << std::endl;
@@ -2307,8 +2313,8 @@ bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &p
                 std::chrono::duration<double> elapsed_secondsu = endu - startu;
                 std::time_t end_timeu = std::chrono::system_clock::to_time_t(endu);
 
-                std::cout << "finished computation at " << std::ctime(&end_timeu)
-                          << "elapsed time update: " << elapsed_secondsu.count() << "s\n";
+                //std::cout << "finished computation at " << std::ctime(&end_timeu)
+                //          << "elapsed time update: " << std::setprecision(0) << elapsed_secondsu.count() << "s\n";
             }
             else
             {
@@ -2343,8 +2349,9 @@ bool compute_step_2(std::vector<WorkerData> &worker_data, LidarOdometryParams &p
         std::chrono::duration<double> elapsed_seconds = end - start;
         std::time_t end_time = std::chrono::system_clock::to_time_t(end);
 
-        std::cout << "finished computation at " << std::ctime(&end_time)
-                  << "elapsed time: " << elapsed_seconds.count() << "s\n";
+        std::tm local_tm = *std::localtime(&end_time);
+        std::cout << "finished computation at " << std::put_time(&local_tm, "%Y-%m-%d %H:%M:%S")
+            << ", elapsed time: " << std::setprecision(2) << elapsed_seconds.count() << "s\n";
 
         params.total_length_of_calculated_trajectory = 0;
         for (int i = 1; i < worker_data.size(); i++)

--- a/core/include/export_laz.h
+++ b/core/include/export_laz.h
@@ -110,7 +110,7 @@ inline bool exportLaz(const std::string &filename,
         return false;
     }
 
-    fprintf(stderr, "writing file '%s' %scompressed\n", filename.c_str(), (compress ? "" : "un"));
+    fprintf(stderr, "writing %scompressed file '%s'\n", (compress ? "" : "un"), filename.c_str());
 
     // get a pointer to the point of the writer that we will populate and write
 
@@ -169,8 +169,6 @@ inline bool exportLaz(const std::string &filename,
         fprintf(stderr, "DLL ERROR: destroying laszip writer\n");
         return false;
     }
-
-    std::cout << "exportLaz DONE" << std::endl;
 
     return true;
 }

--- a/core/include/pfd_wrapper.hpp
+++ b/core/include/pfd_wrapper.hpp
@@ -7,14 +7,14 @@ namespace mandeye::fd{
         static  std::string lastLocationHint = ".";//"C:\\";
     }
     const std::vector<std::string> LAS_LAZ_filter = {"LAS file (*.laz)", "*.laz", "LASzip file (*.las)", "*.las", "All files", "*"};
-    const std::vector<std::string> ImageFilter = { "Image Files", "*.png *.jpg *.jpeg *.bmp"};
+    const std::vector<std::string> ImageFilter = { "Image files", "*.png *.jpg *.jpeg *.bmp"};
     const std::vector <std::string> LazFilter = { "LAZ files (*.laz)", "*.laz *.las" };
     const std::vector<std::string> Session_filter = { "Session (*.json)", "*.json" };
     const std::vector<std::string> Resso_filter = { "Resso, (*.reg)", "*.reg" };
     const std::vector<std::string> Dxf_filter = { "dxf (*.dxf)", "*.dxf" };
     const std::vector<std::string> Csv_filter = { "Csv (*.csv)", "*.csv" };
     const std::vector<std::string> Toml_filter = {"Toml (*.toml)", "*.toml"};
-    const std::vector<std::string> All_Filter = {"All Files", "*.png *.jpg *.jpeg *.bmp *.las *.laz *.json *.dxf *.csv *.sn"};
+    const std::vector<std::string> All_Filter = {"All files", "*.png *.jpg *.jpeg *.bmp *.las *.laz *.json *.dxf *.csv *.sn"};
 
     std::string OpenFileDialogOneFile(const std::string& title, const std::vector<std::string>&filter);
     std::vector<std::string> OpenFileDialog(const std::string& title, const std::vector<std::string>&filter, bool multiselect);


### PR DESCRIPTION
- clearing concepts and naming (basic lidar odometry guy instead of simple since full lidar odometry gui can be simple or actually full, add measuring units, expand names, user friendly messages, etc)
- add full_processing_messages checkbox to reduce number of messages in console
- added tooltips
- formatting changes for single_gui/full_gui (renames, explanations, measuring units, placings, etc)
- formatting changes for console output (reduce number of messages, rephrase, format, etc)
- select folder instead of files (quicker/easier)
- highlight preselected param settings
- allow mouse scroll in sub-windows
- add close button for full_lidar_odometry_gui
- don't crash if data selection canceled in quick_lidar_odometry_gui
- better calibration file handling (load any json file present since not only calibration.json since mandeye_mission_recorder_calibration doesn't enforce name), warn if file not present for 2 Lidar files
- better error handling of missing files
- use only first sn file found since all are the same in a session