### PR TITLE
Overall multi_view_tls_registration improvements and bugfixes:

### DIFF
--- a/core/include/pfd_wrapper.hpp
+++ b/core/include/pfd_wrapper.hpp
@@ -9,7 +9,7 @@ namespace mandeye::fd{
     const std::vector<std::string> LAS_LAZ_filter = {"LAS file (*.laz)", "*.laz", "LASzip file (*.las)", "*.las", "All files", "*"};
     const std::vector<std::string> ImageFilter = { "Image files", "*.png *.jpg *.jpeg *.bmp"};
     const std::vector <std::string> LazFilter = { "LAZ files (*.laz)", "*.laz *.las" };
-    const std::vector<std::string> Session_filter = { "Session (*.json)", "*.json" };
+    const std::vector<std::string> Session_filter = { "session (*.json)", "session.json" };
     const std::vector<std::string> Resso_filter = { "Resso, (*.reg)", "*.reg" };
     const std::vector<std::string> Dxf_filter = { "dxf (*.dxf)", "*.dxf" };
     const std::vector<std::string> Csv_filter = { "Csv (*.csv)", "*.csv" };


### PR DESCRIPTION
- allow mouse scroll in sub-windows
- add close button for gui's
- formatting changes for gui's (renames, explanations, measuring units, placings, etc)
- in Load session filter for session.json not just any json since name is hardwired in step_1
- add ctrl+right click to change center of rotation, easier to use anywhere
- add ctrl+left click to select CP/GCP, easier to use anywhere
- old style ctrl+middle click still works for shared center of rotation/selection of CP/GCP but is shared (can't change center of rotation if CP/GCP GUI active)
- CP/GCP selector always active when GUI active