### PR TITLE
Use Eigen as header only lib and prevent from opening Fortran project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,23 +205,9 @@ include(cmake/imgui.cmake)
 include(cmake/imguizmo.cmake)
 include(cmake/implot.cmake)
 
-# Option to build with bundled Eigen
-option(BUILD_WITH_BUNDLED_EIGEN "Build with bundled Eigen" ON)
-if (BUILD_WITH_BUNDLED_EIGEN)
-    set(EIGEN_BUILD_DOC
-            OFF
-            CACHE BOOL "" FORCE)
-    set(EIGEN_BUILD_TESTING
-            OFF
-            CACHE BOOL "" FORCE)
-
-    add_subdirectory(${EXTERNAL_LIBRARIES_DIRECTORY}/eigen)
-    set(EIGEN3_INCLUDE_DIR ${EXTERNAL_LIBRARIES_DIRECTORY}/eigen)
-    MESSAGE(STATUS "Using bundled Eigen3 : ${EIGEN_INCLUDE_DIR}")
-else()
-    find_package(Eigen3 REQUIRED)
-    MESSAGE(STATUS "Found Eigen3: ${EIGEN3_INCLUDE_DIR}")
-endif()
+add_subdirectory(${EXTERNAL_LIBRARIES_DIRECTORY}/eigen)
+set(EIGEN3_INCLUDE_DIR ${EXTERNAL_LIBRARIES_DIRECTORY}/eigen)
+MESSAGE(STATUS "Using bundled Eigen3 : ${EIGEN3_INCLUDE_DIR}")
 
 option(BUILD_WITH_BUNDLED_FREEGLUT "Build with bundled FreeGlut" ON)
 if (BUILD_WITH_BUNDLED_FREEGLUT)


### PR DESCRIPTION
Current version when configuring using CMake on Windows will try to open Visual Studio Fortran project:

<img width="1416" height="944" alt="image" src="https://github.com/user-attachments/assets/1efd1307-777a-46bb-9a1c-c68b757591a3" />

These changes prevent it from happening. Also Eigen works fine as header only library so there is no need to __add_subdirectory()__.

This PR is part of issue : [197](https://github.com/MapsHD/HDMapping/issues/197)