### PR TITLE
File handling changes and bugfixes

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry_gui.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_gui.cpp
@@ -164,8 +164,6 @@ void step1(const std::atomic<bool> &loPause)
 {
     std::string input_folder_name;
     std::vector<std::string> input_file_names;
-    // input_file_names = mandeye::fd::OpenFileDialog("Load las files", {}, true);
-    // input_file_names = mandeye::fd::OpenFileDialog("Load all files", mandeye::fd::All_Filter, true);
     input_folder_name = mandeye::fd::SelectFolder("Select Mandeye data folder");
 
     std::cout << "Selected folder: '" << input_folder_name << std::endl;
@@ -178,20 +176,8 @@ void step1(const std::atomic<bool> &loPause)
             glutSetWindowTitle(newTitle.c_str());
 
             for (const auto &entry : fs::directory_iterator(input_folder_name))
-            {
                 if (entry.is_regular_file())
-                {
                     input_file_names.push_back(entry.path().string());
-                }
-            }
-            // std::cout << "input_file_names list begin" << std::endl;
-            // std::cout << "----------------------" << std::endl;
-            // for (const auto& fn : input_file_names)
-            //{
-            //     std::cout << "'" << fn << "'" << std::endl;
-            // }
-            // std::cout << "----------------------" << std::endl;
-            // std::cout << "input_file_names list end" << std::endl;
 
             if (load_data(input_file_names, params, pointsPerFile, imu_data, full_debug_messages))
             {
@@ -394,7 +380,8 @@ void lidar_odometry_gui()
 
         if (!simple_gui)
         {
-            ImGui::InputInt("THRESHOLD_NR_POSES", &params.threshold_nr_poses);
+			ImGui::SetNextItemWidth(ImGuiNumberWidth);
+            ImGui::InputInt("Threshold nr poses", &params.threshold_nr_poses);
             if (params.threshold_nr_poses < 1)
             {
                 params.threshold_nr_poses = 1;
@@ -413,7 +400,7 @@ void lidar_odometry_gui()
         }
 
         ImGui::PushItemWidth(ImGuiNumberWidth);
-        ImGui::InputDouble("filter_threshold_xy_inner [m]", &params.filter_threshold_xy_inner, 0.0, 0.0, "%.3f");
+        ImGui::InputDouble("Filter threshold XY inner [m]", &params.filter_threshold_xy_inner, 0.0, 0.0, "%.3f");
         if (ImGui::IsItemHovered())
         {
             ImGui::BeginTooltip();
@@ -423,7 +410,7 @@ void lidar_odometry_gui()
             ImGui::Text("e.g.: 0.1[m] for Livox Mid-360");
             ImGui::EndTooltip();
         }
-        ImGui::InputDouble("filter_threshold_xy_outer [m]", &params.filter_threshold_xy_outer, 0.0, 0.0, "%.3f");
+        ImGui::InputDouble("Filter threshold XY outer [m]", &params.filter_threshold_xy_outer, 0.0, 0.0, "%.3f");
         if (ImGui::IsItemHovered())
         {
             ImGui::BeginTooltip();
@@ -433,7 +420,7 @@ void lidar_odometry_gui()
             ImGui::Text("e.g.: 70[m] @ 80%% reflectivity for Livox Mid-360");
             ImGui::EndTooltip();
         }
-        ImGui::InputDouble("threshold_output_filter [m]", &params.threshould_output_filter, 0.0, 0.0, "%.3f");
+        ImGui::InputDouble("Threshold output filter [m]", &params.threshould_output_filter, 0.0, 0.0, "%.3f");
         if (ImGui::IsItemHovered())
             ImGui::SetTooltip("all local points inside lidar xy_circle radius will be removed during save");
         ImGui::PopItemWidth();
@@ -493,22 +480,17 @@ void lidar_odometry_gui()
 
             ImGui::NewLine();
 
-            // ImGui::InputDouble("filter_threshold_xy (all local points inside lidar xy_circle radius[m] will be removed during load)", &params.filter_threshold_xy);
-            // ImGui::InputDouble("threshould_output_filter (all local points inside lidar xy_circle radius[m] will be removed during save)", &threshould_output_filter);
-
-            ImGui::InputDouble("decimation", &params.decimation, 0.0, 0.0, "%.3f");
+            ImGui::InputDouble("Decimation", &params.decimation, 0.0, 0.0, "%.3f");
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("larger value of decimation better performance, but worse accuracy");
+                ImGui::SetTooltip("Larger value of decimation better performance, but worse accuracy");
 
-            ImGui::InputDouble("max distance of processed points [m]", &params.max_distance_lidar, 0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Max distance of processed points [m]", &params.max_distance_lidar, 0.0, 0.0, "%.2f");
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("local LiDAR coordinates");
+                ImGui::SetTooltip("Local LiDAR coordinates");
 
-            ImGui::InputInt("number iterations", &params.nr_iter);
-            ImGui::InputDouble("sliding window trajectory length threshold [m]", &params.sliding_window_trajectory_length_threshold, 0.0, 0.0, "%.2f");
-            ImGui::InputInt("threshold initial points", &params.threshold_initial_points);
-            ImGui::Checkbox("save_calibration_validation_file", &params.save_calibration_validation);
-            ImGui::InputInt("number of calibration validation points", &params.calibration_validation_points);
+            ImGui::InputInt("Number of iterations", &params.nr_iter);
+            ImGui::InputDouble("Sliding window trajectory length threshold [m]", &params.sliding_window_trajectory_length_threshold, 0.0, 0.0, "%.2f");
+            ImGui::InputInt("Threshold initial points", &params.threshold_initial_points);
 
             ImGui::NewLine();
 
@@ -517,9 +499,9 @@ void lidar_odometry_gui()
             if (fusionConvention < 0 || fusionConvention > 2)
                 fusionConvention = 0;
 
-            ImGui::Text("fusion convention: ");
+            ImGui::Text("Fusion convention: ");
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("coordinate system conventions for sensor fusion defining how the axes are oriented relative to world frame");
+                ImGui::SetTooltip("Coordinate system conventions for sensor fusion defining how the axes are oriented relative to world frame");
 
             ImGui::SameLine();
             ImGui::RadioButton("NWU", &fusionConvention, 0);
@@ -541,8 +523,16 @@ void lidar_odometry_gui()
 
             ImGui::NewLine();
 
-            ImGui::Checkbox("use_motion_from_previous_step", &params.use_motion_from_previous_step);
-            ImGui::InputDouble("ahrs_gain", &params.ahrs_gain, 0.0, 0.0, "%.3f");
+            ImGui::Checkbox("Use motion from previous step", &params.use_motion_from_previous_step);
+            ImGui::InputDouble("AHRS gain", &params.ahrs_gain, 0.0, 0.0, "%.3f");
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::BeginTooltip();
+                ImGui::Text("Attitude and Heading Reference System gain:");
+                ImGui::Text("How strongly the accelerometer/magnetometer corrections influence the orientation estimate versus gyroscope integration");
+                ImGui::Text("Larger value means faster response to changes in orientation, but more noise");
+                ImGui::EndTooltip();
+            }
 
             ImGui::PopItemWidth();
         }
@@ -551,41 +541,49 @@ void lidar_odometry_gui()
         {
             if (ImGui::Button("Load data"))
             {
+                loStartTime = std::chrono::system_clock::now();
+                
                 step1(loPause);
                 std::cout << "Load data done please click 'Compute all' to continue calculations" << std::endl;
+
+                std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - loStartTime;
+                double elapsedSeconds = elapsed.count();
+
+                std::cout << "Elapsed time: " << formatTime(elapsedSeconds).c_str() << std::endl;
+
             }
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("Select all imu *.csv and lidar *.laz files produced by MANDEYE saved in 'continousScanning_*' folder");
+                ImGui::SetTooltip("Select all IMU *.csv and LiDAR *.laz files produced by MANDEYE saved in 'continousScanning_*' folder");
         }
         if (step_1_done && !step_2_done)
         {
             if (ImGui::Button("Compute all"))
-            {
                 step2(loPause);
-            }
+
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("Press this button for automatic lidar odometry calculation -> it will produce trajectory");
+                ImGui::SetTooltip("Press this button for automatic LiDAR odometry calculation -> it will produce trajectory");
         }
 
         if (step_1_done && step_2_done)
         {
-            ImGui::Text("'Point cloud consistency and trajectory smoothness' makes trajectory smooth, point cloud will be more consistent");
-
             if (ImGui::Button("Point cloud consistency and trajectory smoothness"))
-            {
                 run_consistency(worker_data, params);
-            }
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("Press optionally before pressing 'Save result");
+            {
+                ImGui::BeginTooltip();
+				ImGui::Text("This process makes trajectory smooth, point cloud will be more consistent");
+                ImGui::SetTooltip("Press optionally before pressing 'Save result'");
+                ImGui::EndTooltip();
+            }
+                
             ImGui::SameLine();
             ImGui::Checkbox("Use multiple Gaussians for each bucket", &params.use_mutliple_gaussian);
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("Multiple Gaussians suppose to work better in floor plan indoor scenarios (multiple neighbouring rooms)");
 
             if (ImGui::Button("Save result"))
-            {
                 save_results(true, 0.0);
-            }
+
             ImGui::SameLine();
             ImGui::Text("Press this button for saving resulting trajectory and point clouds as single session for 'multi_view_tls_registration_step_2' program");
         }
@@ -1648,24 +1646,36 @@ void display()
             if (ImGui::BeginMenu("Parameters"))
             {
 
-                ImGui::MenuItem("use_removie_imu_bias_from_first_stationary_scan", nullptr, &params.use_removie_imu_bias_from_first_stationary_scan);
-                ImGui::MenuItem("use_multithread", nullptr, &params.useMultithread);
-                ImGui::MenuItem("full_processing_messages", nullptr, &full_debug_messages);
+                ImGui::MenuItem("Remove IMU bias from first stationary scan", nullptr, &params.use_removie_imu_bias_from_first_stationary_scan);
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("Show more messages during processing in console window");
+					ImGui::SetTooltip("IMU bias will be removed given there's a stationary period at the start of the recording");
 
+                ImGui::MenuItem("Multithread", nullptr, &params.useMultithread);
                 ImGui::PushItemWidth(ImGuiNumberWidth / 2);
-                ImGui::InputDouble("time_threshold [s]", &params.real_time_threshold_seconds, 0.0, 0.0, "%.1f");
+                ImGui::InputDouble("Time threshold [s]", &params.real_time_threshold_seconds, 0.0, 0.0, "%.1f");
                 ImGui::PopItemWidth();
                 if (ImGui::IsItemHovered())
                 {
                     ImGui::BeginTooltip();
-                    ImGui::Text("optimization timeout");
+                    ImGui::Text("Optimization timeout");
                     ImGui::Text("smaller value gives faster calculations, less precise results");
                     ImGui::Text("e.g.: 0.1 [s] will make processing time aprox equal to scan time");
                     ImGui::Text("0.3 [s] will make processing time aprox equal to 3x scan time");
                     ImGui::EndTooltip();
                 }
+
+                ImGui::Separator();
+
+				ImGui::Text("Debug:");
+
+                ImGui::MenuItem("Full processing messages", nullptr, &full_debug_messages);
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip("Show more messages during processing in console window");
+                ImGui::MenuItem("Save calibration validation file", nullptr, &params.save_calibration_validation);
+                if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("Save calibrated points from first laz file in 'calibrationValidation.asc' file");
+				ImGui::SetNextItemWidth(ImGuiNumberWidth);
+                ImGui::InputInt("Number of calibration validation points", &params.calibration_validation_points);
 
                 ImGui::Separator();
 
@@ -1790,7 +1800,7 @@ void display()
 
     if (info_gui)
     {
-        infoLines[infoLines.size() - 2] = "It saves session.json file in " + working_directory + "\\lidar_odometry_result_*";
+        infoLines[infoLines.size() - 2] = "It saves session file in " + working_directory + "\\lidar_odometry_result_*";
         info_window(infoLines, &info_gui);
     }
 

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.h
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.h
@@ -75,7 +75,7 @@ struct LidarOdometryParams
     int threshold_nr_poses = 20;
 
     //lidar odometry debug info
-    bool save_calibration_validation = true;
+    bool save_calibration_validation = false;
     int calibration_validation_points = 1000000;
 
     //consistency
@@ -233,7 +233,7 @@ bool load_point_sizes(const std::filesystem::path &path, std::vector<int> &vecto
 bool load_index_poses(const std::filesystem::path &path, std::vector<std::vector<int>> &index_poses_out);
 bool load_worker_data_from_results(const fs::path &session_file, std::vector<WorkerData> &worker_data_out);
 
-//! This namespace contains functions for loading calibration file (.json and .sn).
+//! This namespace contains functions for loading calibration file (.json/.mjc and .sn).
 //!
 //! Calibration file is a json file with the following format:
 //!{```json
@@ -280,7 +280,7 @@ namespace MLvxCalib
 {
 
     //! Parse the calibration file and return a map from sensor id to serial number.
-    //! Sensor id is the id is id of the point in laz file.
+    //! Sensor id is the id of the point in laz file.
     //! Serial number is the serial number of the Livox.
     //! @param filename calibration file
     //! @return map of serial number, where key is sensor id.

--- a/apps/multi_session_registration/multi_session_registration.cpp
+++ b/apps/multi_session_registration/multi_session_registration.cpp
@@ -2074,14 +2074,14 @@ void openProject()
 void saveProject()
 {
     std::string output_file_name = "";
-    output_file_name = mandeye::fd::SaveFileDialog("Save project file", mandeye::fd::Project_filter, ".json");
+    output_file_name = mandeye::fd::SaveFileDialog("Save project file", mandeye::fd::Project_filter, ".mjp", "project");
 
-if (output_file_name.size() > 0)
-if (save_project_settings(fs::path(output_file_name).string(), project_settings))
-{
-    std::string newTitle = winTitle + " - " + truncPath(output_file_name);
-    glutSetWindowTitle(newTitle.c_str());
-}
+    if (output_file_name.size() > 0)
+        if (save_project_settings(fs::path(output_file_name).string(), project_settings))
+        {
+            std::string newTitle = winTitle + " - " + truncPath(output_file_name);
+            glutSetWindowTitle(newTitle.c_str());
+        }
 }
 
 void addSession()

--- a/apps/multi_view_tls_registration/multi_view_tls_registration.cpp
+++ b/apps/multi_view_tls_registration/multi_view_tls_registration.cpp
@@ -476,13 +476,13 @@ void run_multi_view_tls_registration(
 		std::cout << "Provided input path does not exist." << std::endl;
 		return;
 	}
-	if (has_extension(input_file_name, ".json"))
+	if (has_extension(input_file_name, ".json") || has_extension(input_file_name, ".mjs"))
 	{
 		std::cout << "Session file: '" << input_file_name << "'" << std::endl;
 		session.working_directory = fs::path(input_file_name).parent_path().string();
 		session.load(fs::path(input_file_name).string(), tls_registration.is_decimate, tls_registration.bucket_x, tls_registration.bucket_y, tls_registration.bucket_z, tls_registration.calculate_offset);
 	}
-	else if (has_extension(input_file_name, ".reg"))
+	else if (has_extension(input_file_name, ".reg") || has_extension(input_file_name, ".mjp"))
 	{
 		std::cout << "RESSO file: '" << input_file_name << "'" << std::endl;
 		session.working_directory = fs::path(input_file_name).parent_path().string();
@@ -693,19 +693,20 @@ void run_multi_view_tls_registration(
 	{
 		if (session.point_clouds_container.initial_poses_file_name.empty() && tls_registration.save_initial_poses)
 		{
-			std::string initial_poses_file_name = (outwd / "initial_poses.reg").string();
+			std::string initial_poses_file_name = (outwd / "session_step2_ini_poses.mri").string();
 			std::cout << "saving initial poses to: " << initial_poses_file_name << std::endl;
 			session.point_clouds_container.save_poses(initial_poses_file_name, false);
 		}
 
 		if (session.point_clouds_container.poses_file_name.empty() && tls_registration.save_poses)
 		{
-			std::string poses_file_name = (outwd / "poses.reg").string();
+			std::string poses_file_name = (outwd / "session_step2_poses.mrp").string();
 			std::cout << "saving poses to: " << poses_file_name << std::endl;
 			session.point_clouds_container.save_poses(poses_file_name, false);
 		}
+
 		session.save(
-			(outwd / "session_step_2.json").string(), session.point_clouds_container.poses_file_name,
+			(outwd / "session_step2.mjs").string(), session.point_clouds_container.poses_file_name,
 			session.point_clouds_container.initial_poses_file_name, false);
 		std::cout << "saving result to: " << session.point_clouds_container.poses_file_name << std::endl;
 		session.point_clouds_container.save_poses(fs::path(session.point_clouds_container.poses_file_name).string(), false);

--- a/core/include/pfd_wrapper.hpp
+++ b/core/include/pfd_wrapper.hpp
@@ -9,8 +9,14 @@ namespace mandeye::fd{
     const std::vector<std::string> LAS_LAZ_filter = {"LASzip file (*.laz)", "*.laz", "LAS file (*.las)", "*.las", "All files", "*"};
     const std::vector <std::string> LazFilter = { "LAZ files (*.laz)", "*.laz *.las" };
     const std::vector<std::string> ImageFilter = { "Image files", "*.png *.jpg *.jpeg *.bmp"};
-    const std::vector<std::string> Session_filter = { "Session (*.json)", "*.json" };
-    const std::vector<std::string> Project_filter = { "Project, json", "*.json" };
+
+    const std::vector<std::string> Calibration_filter = { "Mandeye JSON Calibration (*.mjc)", "*.mjc", "Generic JSON (*.json)", "*.json" };
+    const std::vector<std::string> Session_filter = { "Mandeye JSON Session (*.mjs)", "*.mjs", "Generic JSON (*.json)", "*.json" };
+    const std::vector<std::string> Project_filter = { "Mandeye JSON Project (*.mjp)", "*.mjp", "Generic JSON (*.json)", "*.json" };
+
+    const std::vector<std::string> IniPoses_filter = { "Mandeye REG Initial poses (*.mri)", "*.mri", "Generic REG initial poses (*.reg)", "*.reg" };
+    const std::vector<std::string> Poses_filter = { "Mandeye REG Poses (*.mrp)", "*.mrp", "Generic REG poses (*.reg)", "*.reg" };
+
     const std::vector<std::string> Resso_filter = { "Resso (*.reg)", "*.reg" };
     const std::vector<std::string> Dxf_filter = { "dxf (*.dxf)", "*.dxf" };
     const std::vector<std::string> Csv_filter = { "Csv (*.csv)", "*.csv" };


### PR DESCRIPTION
- step1/ changed default for save_calibration_validation from false to true (usefull only for low level debugging)
- step1/ improved labels
- calibration / improved labels and display, overall eficiency, keep track of opened calib file name when saving, fixed bug when using existing calibration file didn't load the chosen_imu and calibrated_lidar
- step2/ fix renamed "Save session" to "Save session as" and have matching poses/ini_poses files when saving
- added mjc extenssion for calibration files
- added mjs extenssion for session files
- added mjp extenssion for project files
- added mri extenssion for initial poses
- added mrp extension for poses (old extensions and filenames still possible)