### PR TITLE
Add .clang-format and run run_clang_format.py script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,61 @@
+Language: Cpp
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    BeforeLambdaBody: true
+    AfterStruct: true
+    BeforeElse: true
+    SplitEmptyFunction: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+ColumnLimit: 140
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+IndentCaseBlocks: true
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+SortIncludes: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+Standard: c++17
+UseTab: Never

--- a/run_clang_format.py
+++ b/run_clang_format.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+
+PROJECT_DIRECTORY = os.path.join(os.path.abspath(os.path.dirname(__file__)))
+
+FILE_LOCATIONS = [os.path.join(PROJECT_DIRECTORY, 'core'),
+                  os.path.join(PROJECT_DIRECTORY, 'core_hd_mapping'),
+                  os.path.join(PROJECT_DIRECTORY, 'apps'),
+                  os.path.join(PROJECT_DIRECTORY, 'pybind'),
+                  os.path.join(PROJECT_DIRECTORY, 'shared')]
+
+FILE_EXTENSIONS = ['.cpp',
+                   '.hpp',
+                   '.c',
+                   '.h']
+
+
+def get_files(input_paths: list[str], extensions: list[str]):
+    files = []
+
+    for input_path in input_paths:
+        for (dirpath, dirnames, filenames) in os.walk(input_path):
+            for filename in filenames:
+                if filename.endswith(tuple(extensions)):
+                    files.append(os.path.join(dirpath, filename))
+    return files
+
+
+def format_file(file_path: str):
+    print(f'Formatting: {file_path}')
+
+    command = ['clang-format',  '-i', file_path]
+    return subprocess.run(command).returncode
+
+
+def format_files(file_paths: list[str]):
+    for file_path in file_paths:
+        format_file(file_path)
+
+
+def main():
+    format_files(get_files(FILE_LOCATIONS, FILE_EXTENSIONS))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
To format repository run:

```bash
python3 run_clang_format.py
```

### Note: forst format should be in another PR and before that all thirdparty should be relocated to __3rdparty__ directory (see : *HDMapping/apps/lidar_odometry_step_1/toml.hpp*)

### Note: CI check for code format should be added in another PR

### Note: .clang-format copied from suggestion in #257 