### PR TITLE
Add missing /bigobj for concatenate_multi_livox

### DIFF
--- a/apps/concatenate_multi_livox/CMakeLists.txt
+++ b/apps/concatenate_multi_livox/CMakeLists.txt
@@ -35,4 +35,8 @@ if(WIN32)
     COMMAND_EXPAND_LISTS)
 endif()
 
+if (MSVC)
+    target_compile_options(concatenate_multi_livox PRIVATE /bigobj)
+endif()
+
 install (TARGETS concatenate_multi_livox DESTINATION bin)


### PR DESCRIPTION
Added :

if (MSVC)
    target_compile_options(concatenate_multi_livox PRIVATE /bigobj)
endif()


to concatenate_multi_livox CMakeLists.txt as it uses lidar_odometry_utils.cpp from  other app which causes error on Windows during build