### PR TITLE
Fix OpenCV build with Visual Studio 2026

### DIFF
--- a/3rdpartyBinary/OpenCV/CMakeLists.txt
+++ b/3rdpartyBinary/OpenCV/CMakeLists.txt
@@ -13,9 +13,9 @@ endif()
 
 if (WIN32)
     # Download OpenCV precompiled self-extractig 
-    set(OPENCV_DOWNLOAD_EXE_URL "https://github.com/opencv/opencv/releases/download/4.12.0/opencv-4.12.0-windows.exe")
-    set(OPENCV_DOWNLOAD_EXE_SHA256 "b753b14d880b9bc8d89d6acd3b665c040baec0211078435432fcae117db707af")
-    set(OPENCV_DOWNLOAD_EXE "${CMAKE_BINARY_DIR}/opencv-4.12.0-windows.exe")
+    set(OPENCV_DOWNLOAD_EXE_URL "https://github.com/opencv/opencv/releases/download/4.13.0/opencv-4.13.0-windows.exe")
+    set(OPENCV_DOWNLOAD_EXE_SHA256 "f0e98c302464d6860777a7015065e11b9b271b5394e6ba92663f0cf1fc303f2c")
+    set(OPENCV_DOWNLOAD_EXE "${CMAKE_BINARY_DIR}/opencv-4.13.0-windows.exe")
 
 
     if(NOT EXISTS ${OPENCV_DOWNLOAD_EXE})


### PR DESCRIPTION
This PR fixes a build issue when configuring the project with latest Visual Studio 2026.

When opening the CMake project in VS 2026, CMake downloads OpenCV 4.12.0, but configuration fails with:
  "Found OpenCV Windows Pack but it has no binaries compatible with your configuration."

This happens because OpenCV 4.12 does not provide Windows binaries compatible with the MSVC toolset used by Visual Studio 2026. Support was added in OpenCV 4.13.

The fix updates the downloaded OpenCV version to 4.13.0 for Windows builds.  
Linux builds are unchanged.

Tested with:
- Visual Studio 2026
- CMake configuration on Windows (x64)
