### PR TITLE
Optimize Lidar Odometry: Unified Hessian Loop and Bucket Linking

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.h
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cmath>
 #include <execution>
 #include <filesystem>
 #include <iostream>
@@ -31,7 +32,9 @@
 
 namespace fs = std::filesystem;
 
-using NDTBucketMapType = ankerl::unordered_dense::map<uint64_t, NDT::Bucket>;
+// segmented_map provides pointer stability - pointers to values remain valid after insertions.
+// This is required for NDT::Bucket::coarser_bucket pointer optimization in link_buckets_to_coarser().
+using NDTBucketMapType = ankerl::unordered_dense::segmented_map<uint64_t, NDT::Bucket>;
 using NDTBucketMapType2 = ankerl::unordered_dense::map<uint64_t, NDT::Bucket2>;
 
 // Helper function for getting software version from CMake macros
@@ -160,12 +163,42 @@ Eigen::Matrix4d getInterpolatedPose(const std::map<double, Eigen::Matrix4d>& tra
 // this function reduces number of points by preserving only first point for each bucket {bucket_x, bucket_y, bucket_z}
 std::vector<Point3Di> decimate(const std::vector<Point3Di>& points, double bucket_x, double bucket_y, double bucket_z);
 
+// Check if outdoor bucket size is integer multiple of indoor bucket size
+bool is_integer_bucket_ratio(const NDT::GridParameters& rgd_params_indoor, const NDT::GridParameters& rgd_params_outdoor);
+
+// Link indoor buckets to their corresponding outdoor buckets via coarser_bucket pointer
+void link_buckets_to_coarser(
+    const NDT::GridParameters& rgd_params_indoor,
+    NDTBucketMapType& buckets_indoor,
+    const NDT::GridParameters& rgd_params_outdoor,
+    const NDTBucketMapType& buckets_outdoor);
+
 // this function updates each bucket (mean value, covariance) in regular grid decomposition
 void update_rgd(
     const NDT::GridParameters& rgd_params,
     NDTBucketMapType& buckets,
     const std::vector<Point3Di>& points_global,
-    const Eigen::Vector3d& viewport = Eigen::Vector3d(0, 0, 0));
+    const Eigen::Vector3d& viewport = Eigen::Vector3d(0, 0, 0),
+    size_t* lookup_count = nullptr);
+
+// Statistics for bucket lookups (used for performance analysis)
+struct LookupStats
+{
+    size_t indoor_lookups = 0;
+    size_t outdoor_lookups = 0;
+    size_t outdoor_pointer_hits = 0; // times coarser_bucket pointer was used instead of lookup
+    double link_time_seconds = 0.0; // cumulative time spent in link_buckets_to_coarser
+};
+
+// hierarchical version: updates both indoor and outdoor, then links buckets
+void update_rgd_hierarchy(
+    const NDT::GridParameters& rgd_params_indoor,
+    NDTBucketMapType& buckets_indoor,
+    const std::vector<Point3Di>& points_global,
+    const Eigen::Vector3d& viewport,
+    const NDT::GridParameters& rgd_params_outdoor,
+    NDTBucketMapType& buckets_outdoor,
+    LookupStats& stats);
 
 void update_rgd_spherical_coordinates(
     const NDT::GridParameters& rgd_params,
@@ -232,7 +265,8 @@ void optimize_lidar_odometry(
     bool ablation_study_use_planarity,
     bool ablation_study_use_norm,
     bool ablation_study_use_hierarchical_rgd,
-    bool ablation_study_use_view_point_and_normal_vectors);
+    bool ablation_study_use_view_point_and_normal_vectors,
+    LookupStats& lookup_stats);
 
 void optimize_sf(
     std::vector<Point3Di>& intermediate_points,

--- a/core/include/ndt.h
+++ b/core/include/ndt.h
@@ -35,12 +35,15 @@ public:
 
     struct Bucket
     {
+        Eigen::Matrix3d cov;
+        Eigen::Matrix3d cov_inverse; // precomputed inverse of cov, updated in update_rgd
+        Eigen::Vector3d mean;
+        Eigen::Vector3d normal_vector;
+        const Bucket* coarser_bucket = nullptr; // pointer to coarser level bucket (e.g., outdoor for indoor)
+
+        uint64_t number_of_points;
         uint64_t index_begin;
         uint64_t index_end;
-        uint64_t number_of_points;
-        Eigen::Vector3d mean;
-        Eigen::Matrix3d cov;
-        Eigen::Vector3d normal_vector;
     };
 
     struct BucketCoef


### PR DESCRIPTION
## Description
This PR improves performance of `optimize_lidar_odometry()` by reducing redundant
computation and hash-map lookups in the Hessian computation step.

## Key changes
- **Unified Hessian loop** – indoor and outdoor contributions are computed together
  in a single `parallel_for`, reducing overhead and improving cache locality.
- **Precomputed covariance inverses** – `cov_inverse` is computed once per bucket
  update and reused during optimization (no per-point matrix inversion).
- **Pointer-based bucket linking** – when indoor/outdoor bucket sizes have an
  integer ratio, indoor buckets store a direct pointer to the corresponding
  outdoor bucket, avoiding hash lookups.

## Performance
Local measurements show a **~10–12% speedup** compared to the previous version
for the optimized code path.

## Note
The intent was to preserve the same underlying math while changing how work is
organized (single hessian computation loop, bucket linking). I tested on a reference dataset
and the trajectory looked consistent, but I would appreciate a careful review of all changes.

--------------

## Detailed Changes

### 1. NDT::Bucket struct (`core/include/ndt.h`)
- Added `Eigen::Matrix3d cov_inverse` - precomputed inverse of covariance matrix
- Added `const Bucket* coarser_bucket` - pointer to corresponding outdoor bucket (for integer bucket ratios)

### 2. New helper functions (`lidar_odometry_utils.cpp`)
- `is_integer_bucket_ratio()` - checks if outdoor/indoor bucket ratio is integer (enables pointer linking)
- `link_buckets_to_coarser()` - links indoor buckets to outdoor buckets via `coarser_bucket` pointer
- `update_rgd_hierarchy()` - parallel update of indoor and outdoor buckets using `tbb::parallel_invoke`, followed by linking

### 3. Precomputed cov_inverse (`lidar_odometry_utils.cpp`)
- `update_rgd()` now computes `cov_inverse` after each `cov` update
- `update_rgd_spherical_coordinates()` also updated for consistency

### 4. Unified hessian computation (`lidar_odometry_utils_optimizers.cpp`)
- New `compute_hessian()` function replaces separate indoor/outdoor loops
- Helper functions: `add_indoor_hessian_contribution()`, `add_outdoor_hessian_contribution()`
- Uses `cov_inverse` instead of computing `cov.inverse()` per point
- Uses `squaredNorm()` instead of `norm()` for range checks (avoids sqrt)
- Indoor and outdoor contributions are independent (indoor miss doesn't skip outdoor)

### 5. Lookup statistics (`lidar_odometry_utils.h`)
- Added `LookupStats` struct: `indoor_lookups`, `outdoor_lookups`, `outdoor_pointer_hits`, `link_time_seconds`
- Tracks hash lookups vs pointer hits for performance analysis

### 6. NDTBucketMapType (`lidar_odometry_utils.h`)
- Uses `ankerl::unordered_dense::segmented_map` for pointer stability (required for `coarser_bucket` optimization)

---------------
## Additional details

### Integer bucket ratios explanation:
When outdoor bucket size is an integer multiple of indoor bucket size (e.g., 0.6m / 0.3m = 2), indoor buckets align perfectly within outdoor buckets. This enables:
- **Pointer linking** - indoor buckets store direct pointer to their outdoor bucket
- **O(1) outdoor access** - pointer dereference instead of hash lookup to outdoor bucket

### Behavior Notes

- Integer bucket ratio (e.g., 0.3m/0.1m = 3): pointer linking enabled, faster outdoor access
- Non-integer ratio (e.g., 0.3m/0.101m): fallback to hash lookup for outdoor buckets

### Important: Pointer Stability Requirement

The `coarser_bucket` pointer optimization requires that pointers to bucket values remain valid after map insertions. This is why `NDTBucketMapType` uses `ankerl::unordered_dense::segmented_map` which guarantees pointer stability.