### PR TITLE
Remove clearing of the first pointcloud

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry.cpp
@@ -294,9 +294,6 @@ bool load_data(
                 pointsPerFile[i] = std::move(data);
             });
 
-        if (pointsPerFile.size() > 0)
-            pointsPerFile.front().clear();
-
         // --- Summary
         size_t totalPoints = 0;
         for (const auto& pp : pointsPerFile)


### PR DESCRIPTION
There is a statement that literally clears first loaded pointcloud.
I completely do not understand that sophisticated logic around that. 
To my taste it is a bug.
<img width="3637" height="1904" alt="image" src="https://github.com/user-attachments/assets/7c199709-a3a6-4b82-8d4b-01d21d99eb51" />
