### PR TITLE
Fix memory not being freed after point cloud decimation

### DIFF
--- a/core/src/point_cloud.cpp
+++ b/core/src/point_cloud.cpp
@@ -1582,6 +1582,13 @@ void PointCloud::decimate(double bucket_x, double bucket_y, double bucket_z)
     intensities = n_intensities;
     timestamps = n_timestamps;
     colors = n_colors;
+
+    points_local.shrink_to_fit();
+    normal_vectors_local.shrink_to_fit();
+    points_type.shrink_to_fit();
+    intensities.shrink_to_fit();
+    timestamps.shrink_to_fit();
+    colors.shrink_to_fit();
 }
 
 void PointCloud::shift_to_center()


### PR DESCRIPTION
### Problem

When decimating point clouds, the `decimate()` function creates new smaller vectors and assigns them to the member vectors. However, `std::vector` assignment does not reduce capacity - it keeps the original memory allocation even when the new data is much smaller.

This meant that even with aggressive decimation, the application retained the full memory footprint of the original undecimated point clouds.

### Solution

Added `shrink_to_fit()` calls after each vector assignment in `PointCloud::decimate()` to release unused memory back to the system.

### Results

Tested on `multi_view_tls_registration_step_2.exe` with a 5km dataset using 0.2m decimation. Before the fix, the application used 80GB of RAM. After the fix, it uses only 10GB - an 88% reduction in memory usage. (Tested on Windows with msvc compiler)

### Files changed

- `core/src/point_cloud.cpp` - Added `shrink_to_fit()` to 6 vectors in `decimate()`