### PR TITLE
Fix Linux compatibility: CRLF and backslash paths

### DIFF
--- a/core/src/point_clouds.cpp
+++ b/core/src/point_clouds.cpp
@@ -1286,6 +1286,9 @@ bool PointClouds::load_whu_tls(
             while (!infile.eof())
             {
                 getline(infile, s);
+                // Remove trailing \r from Windows CRLF line endings
+                if (!s.empty() && s.back() == '\r')
+                    s.pop_back();
                 std::vector<std::string> strs;
                 split(s, ' ', strs);
 

--- a/core/src/session.cpp
+++ b/core/src/session.cpp
@@ -34,7 +34,11 @@ bool Session::load(const std::string& file_name, bool is_decimate, double bucket
     // Local pathUpdater lambda (keep directories unchanged, update files to be in session directory)
     auto getNewPath = [&](const std::string& path) -> std::string
     {
-        fs::path p(path);
+        // Normalize Windows backslashes to forward slashes so that
+        // std::filesystem::path correctly extracts the filename on Linux.
+        std::string normalized = path;
+        std::replace(normalized.begin(), normalized.end(), '\\', '/');
+        fs::path p(normalized);
         if (is_directory(p))
             return p.string();
         return (fs::path(directory) / p.filename()).string();


### PR DESCRIPTION
## Summary
- **point_clouds.cpp**: Strip trailing `\r` from CRLF line endings when loading WHU TLS files, fixing parse errors on Linux
- **session.cpp**: Normalize Windows backslash `\` path separators to forward slashes `/` so `std::filesystem::path` correctly extracts filenames on Linux

These fixes allow HDMapping to work correctly on Linux when processing files created on Windows.