### PR TITLE
Fix LAS specification violations

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry_utils.h
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils.h
@@ -260,9 +260,9 @@ void optimize_lidar_odometry(
     bool ablation_study_use_hierarchical_rgd,
     bool ablation_study_use_view_point_and_normal_vectors,
     LookupStats& lookup_stats,
-    const bool &ablation_study_use_threshold_outer_rgd,
-    const double &convergence_result,
-    const double &convergence_delta_threshold_outer_rgd);
+    const bool& ablation_study_use_threshold_outer_rgd,
+    const double& convergence_result,
+    const double& convergence_delta_threshold_outer_rgd);
 
 void optimize_sf(
     std::vector<Point3Di>& intermediate_points,

--- a/apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp
@@ -1669,10 +1669,9 @@ static void compute_hessian(
     Eigen::MatrixXd& AtPAndt,
     Eigen::MatrixXd& AtPBndt,
     LookupStats& stats,
-    const bool &ablation_study_use_threshold_outer_rgd,
-    const double &convergence_result,
-    const double &convergence_delta_threshold_outer_rgd
-)
+    const bool& ablation_study_use_threshold_outer_rgd,
+    const double& convergence_result,
+    const double& convergence_delta_threshold_outer_rgd)
 {
     const double range_squared = point.point.squaredNorm();
 
@@ -1716,15 +1715,16 @@ static void compute_hessian(
     bool check_threshold_outdoor_rgd = true;
     if (ablation_study_use_threshold_outer_rgd)
     {
-        //const bool ablation_study_use_threshold_outer,
-        //const double convergence_delta_threshold_outer_rgd,
-        //const double convergence_result)
+        // const bool ablation_study_use_threshold_outer,
+        // const double convergence_delta_threshold_outer_rgd,
+        // const double convergence_result)
 
-        //janusz
+        // janusz
 
-        if(convergence_result > convergence_delta_threshold_outer_rgd){
+        if (convergence_result > convergence_delta_threshold_outer_rgd)
+        {
             check_threshold_outdoor_rgd = false;
-            //std::cout << "do not use out " << std::endl;
+            // std::cout << "do not use out " << std::endl;
         }
     }
 
@@ -1780,9 +1780,9 @@ void optimize_lidar_odometry(
     bool ablation_study_use_hierarchical_rgd,
     bool ablation_study_use_view_point_and_normal_vectors,
     LookupStats& lookup_stats,
-    const bool &ablation_study_use_threshold_outer_rgd,
-    const double &convergence_result,
-    const double &convergence_delta_threshold_outer_rgd)
+    const bool& ablation_study_use_threshold_outer_rgd,
+    const double& convergence_result,
+    const double& convergence_delta_threshold_outer_rgd)
 {
     UTL_PROFILER_SCOPE("optimize_lidar_odometry");
     UTL_PROFILER_BEGIN(pre_hessian, "pre_hessian");

--- a/apps/lidar_odometry_step_1/toml_io.cpp
+++ b/apps/lidar_odometry_step_1/toml_io.cpp
@@ -90,10 +90,10 @@ bool TomlIO::SaveParametersToTomlFile(const std::string& filepath, const LidarOd
     out << "[ablacion study]" << std::endl;
     out << "ablation_study_use_norm = " << (params.ablation_study_use_norm ? "true" : "false") << std::endl;
     out << "ablation_study_use_hierarchical_rgd = " << (params.ablation_study_use_hierarchical_rgd ? "true" : "false") << std::endl;
-    out << "ablation_study_use_view_point_and_normal_vectors = " << (params.ablation_study_use_view_point_and_normal_vectors ? "true" : "false") << std::endl;
+    out << "ablation_study_use_view_point_and_normal_vectors = "
+        << (params.ablation_study_use_view_point_and_normal_vectors ? "true" : "false") << std::endl;
     out << "ablation_study_use_threshold_outdoor_rgd = " << (params.ablation_study_use_threshold_outer_rgd ? "true" : "false") << std::endl;
     out << std::endl;
-
 
     // Remove version_info from tbl to avoid duplication since we write it manually
     tbl.erase("version_info");

--- a/core/include/export_laz.h
+++ b/core/include/export_laz.h
@@ -24,8 +24,7 @@ public:
     LazWriter(const LazWriter&) = delete;
     LazWriter& operator=(const LazWriter&) = delete;
 
-    bool open(const std::string& filename,
-              double offset_x, double offset_y, double offset_z)
+    bool open(const std::string& filename, double offset_x, double offset_y, double offset_z)
     {
         constexpr double scale = 0.0001;
 
@@ -76,10 +75,8 @@ public:
         return true;
     }
 
-    bool writePoint(const Eigen::Vector3d& position,
-                    unsigned short intensity,
-                    double timestamp,
-                    double offset_x, double offset_y, double offset_z)
+    bool writePoint(
+        const Eigen::Vector3d& position, unsigned short intensity, double timestamp, double offset_x, double offset_y, double offset_z)
     {
         point_->intensity = intensity;
         point_->return_number = 1;
@@ -163,14 +160,12 @@ inline bool exportLaz(
 
     for (size_t i = 0; i < pointcloud.size(); i++)
     {
-        if (!writer.writePoint(pointcloud[i], intensity[i], timestamps[i],
-                               offset_x, offset_y, offset_alt))
+        if (!writer.writePoint(pointcloud[i], intensity[i], timestamps[i], offset_x, offset_y, offset_alt))
             return false;
     }
 
     return writer.close();
 }
-
 
 // inline Eigen::Vector3d adjustPoint(laszip_F64 input_coordinates[3], const Eigen::Affine3d &m_pose)
 //{

--- a/core/src/utils.cpp
+++ b/core/src/utils.cpp
@@ -1431,8 +1431,8 @@ void getClosestTrajectoriesPoint(
                         else // io.KeyShift
                         {
                             index_loop_closure_target = i;
-                            //time_stamp_offset =
-                            //    sessions[first_session_index].point_clouds_container.point_clouds[i].local_trajectory[j].timestamps.first;
+                            // time_stamp_offset =
+                            //     sessions[first_session_index].point_clouds_container.point_clouds[i].local_trajectory[j].timestamps.first;
                         }
                     }
                 }
@@ -1506,8 +1506,7 @@ void getClosestTrajectoriesPoint(
                             new_rotation_center.y() = static_cast<float>(vp.y());
                             new_rotation_center.z() = static_cast<float>(vp.z());
 
-                            time_stamp_offset =
-                                sessions[s].point_clouds_container.point_clouds[i].local_trajectory[j].timestamps.first;
+                            time_stamp_offset = sessions[s].point_clouds_container.point_clouds[i].local_trajectory[j].timestamps.first;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fix LAS specification violations and reduce memory usage when exporting LAZ files in `core/include/export_laz.h`.

Fixes https://github.com/MapsHD/HDMapping/issues/352
Fixes https://github.com/MapsHD/HDMapping/issues/358

## Changes

### LAS spec compliance fixes

- **Fix `float` scale factor**: `constexpr float scale = 0.0001f` produced `0.000099999997474` in the header due to single-precision limitations. Changed to `double`.
- **Fix bounding box in `exportLaz()`**: Manual min/max computation from raw doubles didn't match quantized coordinates written to the file, causing points to fall outside the header bounding box. Replaced with `laszip_update_inventory()`.
- **Fix bounding box in `save_processed_pc()`**: `adjustHeader()` only transformed 2 of 8 AABB corners, producing an incorrect bounding box when the pose contains rotation. Removed `adjustHeader()` and replaced with `laszip_update_inventory()`.
- **Set return fields**: `return_number` and `number_of_returns` were 0, which is invalid per LAS 1.2 spec (valid range: 1-5). Set both to 1 (single return).

### High memory usage fix

- **Add `LazWriter` helper class**: RAII wrapper around the laszip writer lifecycle (`open`, `writePoint`, `close`). Centralizes LAZ writing logic so multiple callers share the same correct implementation.
- **Refactor `exportLaz()` to use `LazWriter`**: Signature unchanged — all 22 callers across 13 files are unaffected.
- **Refactor `save_all_to_las()` to stream via `LazWriter`**: Previously copied the entire point cloud into three temporary vectors (`pointcloud`, `intensity`, `timestamps`) before writing. For 218M points this duplicated ~7 GB in memory. Now streams points directly to laszip one at a time — only one point in flight instead of all points buffered.

## lasinfo64 report — before

```
  scale factor x y z:         0.000099999997474 0.000099999997474 0.000099999997474
  offset x y z:               0 0 0
  min x y z:                  -554.883007132173816 -355.845426140132588 230.440027620015343
  max x y z:                  796.307733734780186 57.01202975172562 412.955472548385046
WARNING: stored resolution of min_x not compatible with x_offset and x_scale_factor: -554.883007132173816
WARNING: stored resolution of min_y not compatible with y_offset and y_scale_factor: -355.845426140132588
WARNING: stored resolution of min_z not compatible with z_offset and z_scale_factor: 230.440027620015343
WARNING: stored resolution of max_x not compatible with x_offset and x_scale_factor: 796.307733734780186
WARNING: stored resolution of max_y not compatible with y_offset and y_scale_factor: 57.01202975172562
WARNING: stored resolution of max_z not compatible with z_offset and z_scale_factor: 412.955472548385046
  return_number       0          0
  number_of_returns   0          0
  gps_time 1756111314071322144440057856.000000 1756115495286343064304484352.000000
WARNING: 2 points outside of header bounding box
WARNING: for return 1 real number of points by return (0) is different from header entry (218337242).
WARNING: there are 218337242 points with return number 0
WARNING: there are 218337242 points with a number of returns of given pulse of 0
WARNING: real max x larger than header max x by 0.000046
WARNING: real min z smaller than header min z by 0.000033
```

## lasinfo64 report — after

```
  file source ID:             4711
  global_encoding:            1
  version major.minor:        1.2
  point data format:          1
  point data record length:   28
  number of point records:    218337242
  number of points by return: 218337242 0 0 0 0
  scale factor x y z:         0.0001 0.0001 0.0001
  offset x y z:               0 0 0
  min x y z:                  -554.8830 -355.8454 230.4400
  max x y z:                  796.3077 57.0120 412.9555
  return_number       1          1
  number_of_returns   1          1
  gps_time 1756111314071322144440057856.000000 1756115495286343064304484352.000000
```

Zero warnings. (GPS timestamp scaling is a known issue tracked separately.)
