### PR TITLE
Fix non-deterministic lidar odometry

### DIFF
--- a/apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp
+++ b/apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp
@@ -1466,6 +1466,8 @@ static void add_indoor_hessian_contribution(
     if ((infm.array() > threshold).any() || (infm.array() < -threshold).any())
         return;
 
+    // Buckets with < 3 points have normal_vector == Zero (default-initialized),
+    // so dot product is 0 and this check passes - they still contribute to the Hessian.
     if (ablation_study_use_view_point_and_normal_vectors)
     {
         if (indoor_bucket.normal_vector.dot(viewport - indoor_bucket.mean) < 0)
@@ -1572,6 +1574,8 @@ static void add_outdoor_hessian_contribution(
     if ((infm.array() > threshold).any() || (infm.array() < -threshold).any())
         return;
 
+    // Buckets with < 3 points have normal_vector == Zero (default-initialized),
+    // so dot product is 0 and this check passes - they still contribute to the Hessian.
     if (ablation_study_use_view_point_and_normal_vectors)
     {
         if (outdoor_bucket.normal_vector.dot(viewport - outdoor_bucket.mean) < 0)

--- a/core/include/ndt.h
+++ b/core/include/ndt.h
@@ -35,21 +35,21 @@ public:
 
     struct Bucket
     {
-        Eigen::Matrix3d cov;
-        Eigen::Matrix3d cov_inverse; // precomputed inverse of cov, updated in update_rgd
-        Eigen::Vector3d mean;
-        Eigen::Vector3d normal_vector;
+        Eigen::Matrix3d cov = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d cov_inverse = Eigen::Matrix3d::Zero(); // precomputed inverse of cov, updated in update_rgd
+        Eigen::Vector3d mean = Eigen::Vector3d::Zero();
+        Eigen::Vector3d normal_vector = Eigen::Vector3d::Zero();
 
-        uint64_t number_of_points;
-        uint64_t index_begin;
-        uint64_t index_end;
+        uint64_t number_of_points = 0;
+        uint64_t index_begin = 0;
+        uint64_t index_end = 0;
     };
 
     struct BucketCoef
     {
-        Eigen::Vector3d mean;
-        Eigen::Matrix3d cov;
-        Eigen::Vector3d normal_vector;
+        Eigen::Vector3d mean = Eigen::Vector3d::Zero();
+        Eigen::Matrix3d cov = Eigen::Matrix3d::Zero();
+        Eigen::Vector3d normal_vector = Eigen::Vector3d::Zero();
         std::vector<uint64_t> point_indexes;
         bool valid = false;
     };
@@ -57,8 +57,8 @@ public:
     struct Bucket2
     {
         int classification = 0; // 1 - ceiling, 2 - floor
-        uint64_t index_begin_inclusive;
-        uint64_t index_end_exclusive;
+        uint64_t index_begin_inclusive = 0;
+        uint64_t index_end_exclusive = 0;
         // uint64_t number_of_points;
         std::unordered_map<uint64_t, BucketCoef> buckets;
     };


### PR DESCRIPTION
## Problem

Lidar odometry produces different results across runs, in both single-threaded and
multithreaded modes.

## Fix: Zero-initialize NDT bucket structs

### Root cause

Eigen's default constructors intentionally leave matrix/vector members uninitialized
for performance. When NDT bucket structs (`Bucket`, `BucketCoef`, `Bucket2`) are
created, fields like `normal_vector`, `cov`, `mean` contain whatever was in memory.

In `update_rgd()`, when a new bucket is created, `mean`, `cov`, `cov_inverse`, and
`number_of_points` are explicitly set -- but `normal_vector` is not. It only gets
computed when `number_of_points` reaches 3 (via PCA eigenvectors + viewport-based
orientation).

Meanwhile, `compute_hessian()` has no point count guard -- it uses any bucket found
in the map, including those with only 1-2 points. The viewpoint check in
`add_indoor_hessian_contribution()` and `add_outdoor_hessian_contribution()` reads
`normal_vector` unconditionally:

```cpp
if (ablation_study_use_view_point_and_normal_vectors)
{
    if (bucket.normal_vector.dot(viewport - bucket.mean) < 0)
        return;  // skip this bucket's contribution
}
```

With garbage in `normal_vector`, the dot product produces random values, causing
valid buckets to be randomly skipped or included across runs. This is both a
correctness bug (valid observations randomly rejected) and a source of
non-determinism.

### Fix

Added default member initializers to all NDT bucket structs in `core/include/ndt.h`:

- `Bucket`: `cov`, `cov_inverse`, `mean`, `normal_vector` = `Zero()`;
  `number_of_points`, `index_begin`, `index_end` = `0`
- `BucketCoef`: `mean`, `cov`, `normal_vector` = `Zero()`
- `Bucket2`: `index_begin_inclusive`, `index_end_exclusive` = `0`

With `normal_vector` initialized to zero, `Zero().dot(anything) = 0`, which is not
`< 0`, so the viewpoint check consistently passes for buckets with < 3 points.
This matches the intended behavior -- the viewpoint check should only reject buckets
that have a valid surface normal pointing away from the sensor.

Added comments in `add_indoor_hessian_contribution()` and
`add_outdoor_hessian_contribution()` documenting this behavior.

### Files changed

- `core/include/ndt.h`
- `apps/lidar_odometry_step_1/lidar_odometry_utils_optimizers.cpp` (comments only)

## Note on multithreaded Hessian accumulation

The multithreaded Hessian accumulation uses `tbb::combinable` + `combine_each`,
which sums floating-point matrices in an order that varies by thread scheduling.
Since floating-point addition is not associative, this could in theory produce
slightly different results across runs. However, testing showed no noticeable effect
on determinism after the bucket initialization fix above -- the rounding-level
differences from summation order do not propagate into observable output differences.
No changes were made to the accumulation code.

## Testing

Tested on a 5.5 km dataset in both single-threaded and multithreaded modes.
The resulting trajectories are absolutely identical across runs.

## Origin

It is difficult to pinpoint when this bug was introduced from the git log, as the
`normal_vector` field has existed uninitialized in `Bucket` since 2023, and the
viewpoint dot-product check was added, commented out, and uncommented across several
commits. My best guess is `19ebcb0` ("hybhrid approach for LO", Mar 13, 2025) which
uncommented the `nv.dot(viewport - this_bucket.mean) < 0` check in the hessian path
without adding a point count guard.
