### PR TITLE
Step 2 trajectory color

### DIFF
--- a/core/src/point_cloud.cpp
+++ b/core/src/point_cloud.cpp
@@ -1725,7 +1725,7 @@ void PointCloud::render(
         {
             glColor3f(traj_color[0], traj_color[1], traj_color[2]);
 
-            //glColor3f(render_color[0], render_color[1], render_color[2]);
+            // glColor3f(render_color[0], render_color[1], render_color[2]);
 
             glLineWidth(line_width);
             glBegin(GL_LINE_STRIP);


### PR DESCRIPTION
- restored trajectory color control as per View\trajectory menu selections
- if trajectory should follow point cloud color, such menu option exists
- if there is a functional bug then that bug should be addressed without removing the whole functionality which is beneficial and needed (in my opinion)