### PR TITLE
Fix TOML parse error: rename ablacion study section

### DIFF
--- a/apps/lidar_odometry_step_1/toml_io.cpp
+++ b/apps/lidar_odometry_step_1/toml_io.cpp
@@ -87,7 +87,7 @@ bool TomlIO::SaveParametersToTomlFile(const std::string& filepath, const LidarOd
     out << "build_date = \"" << params.build_date << "\"" << std::endl;
     out << std::endl;
 
-    out << "[ablacion study]" << std::endl;
+    out << "[ablation_study]" << std::endl;
     out << "ablation_study_use_norm = " << (params.ablation_study_use_norm ? "true" : "false") << std::endl;
     out << "ablation_study_use_hierarchical_rgd = " << (params.ablation_study_use_hierarchical_rgd ? "true" : "false") << std::endl;
     out << "ablation_study_use_view_point_and_normal_vectors = "


### PR DESCRIPTION
## Summary
- `[ablacion study]` → `[ablation_study]` in TOML save
- Space in section name caused toml++ parse error when reloading saved config
- Section was only written, never loaded — rename is safe and backward compatible

## Test plan
- [x] Save parameters to TOML, reload — verify no parse error