### PR TITLE
Add "All files" fallback to remaining macOS open-dialog file filters

### DIFF
--- a/core/include/Core/pfd_wrapper.hpp
+++ b/core/include/Core/pfd_wrapper.hpp
@@ -16,16 +16,16 @@ namespace mandeye::fd
         "Image files (*.bmp, *.jpg, *.jpeg, *.png)", "*.bmp *.jpg *.jpeg *.png", "All files", "*"
     };
 
-    const std::vector<std::string> Calibration_filter = { "Mandeye JSON Calibration (*.mjc)", "*.mjc", "Generic JSON (*.json)", "*.json" };
-    const std::vector<std::string> Session_filter = { "Mandeye JSON Session (*.mjs)", "*.mjs", "Generic JSON (*.json)", "*.json" };
-    const std::vector<std::string> Project_filter = { "Mandeye JSON Project (*.mjp)", "*.mjp", "Generic JSON (*.json)", "*.json" };
+    const std::vector<std::string> Calibration_filter = { "Mandeye JSON Calibration (*.mjc)", "*.mjc", "Generic JSON (*.json)", "*.json", "All files", "*" };
+    const std::vector<std::string> Session_filter = { "Mandeye JSON Session (*.mjs)", "*.mjs", "Generic JSON (*.json)", "*.json", "All files", "*" };
+    const std::vector<std::string> Project_filter = { "Mandeye JSON Project (*.mjp)", "*.mjp", "Generic JSON (*.json)", "*.json", "All files", "*" };
 
     const std::vector<std::string> IniPoses_filter = {
         "Mandeye REG Initial poses (*.mri)", "*.mri", "Generic REG initial poses (*.reg)", "*.reg"
     };
     const std::vector<std::string> Poses_filter = { "Mandeye REG Poses (*.mrp)", "*.mrp", "Generic REG poses (*.reg)", "*.reg" };
 
-    const std::vector<std::string> Resso_filter = { "RESSO (*.reg)", "*.reg" };
+    const std::vector<std::string> Resso_filter = { "RESSO (*.reg)", "*.reg", "All files", "*" };
     const std::vector<std::string> Dxf_filter = { "DXF file (*.dxf)", "*.dxf" };
     const std::vector<std::string> Csv_filter = { "CSV file (*.csv)", "*.csv" };
     const std::vector<std::string> Toml_filter = { "TOML file (*.toml)", "*.toml", "All files", "*" };


### PR DESCRIPTION
## Problem

On macOS, `portable-file-dialogs` drives the file panels through an AppleScript
`choose file … of type {…}` command. When a filter's type list contains only
extensions that macOS cannot resolve to a known UTI (e.g. `mjc`, `mjs`, `mjp`,
`reg`), the matching files are **greyed out and cannot be selected** in the
*open* panel.

This is the same problem that commit 65436ae fixed for the TOML "Load
parameters" dialog (*"Repair MacOS parameters selection in
lidar_odometry_step_1. Add 'All files' option to TOML file filter"*). The
`LAS_LAZ`, `json` and `sn` filters already carry an `"All files", "*"`
fallback for the same reason.

## Change

Add the same `"All files", "*"` fallback to the remaining filters that are
reachable from **load** dialogs (`OpenFileDialog`/`OpenFileDialogOneFile`)
and still lacked it:

- `Calibration_filter` (`*.mjc`) — "Calibration files"
- `Session_filter` (`*.mjs`) — "Open session"
- `Project_filter` (`*.mjp`) — "Open project"
- `Resso_filter` (`*.reg`) — "Load RESSO"

## Did not change

  Extensions that do no appear in the GUI - no need for this fallback

## Impact

- **macOS:** these files can now be selected in the load dialogs even when the
  type filter would otherwise grey them out.
- **Windows / Linux:** no behaviour change — the specific typed filter stays
  first/default.
- One header-only change to `core/include/Core/pfd_wrapper.hpp`; no API change.