### PR TITLE
Add "All files" fallback to remaining macOS open-dialog file filters

### DIFF
--- a/core/include/Core/pfd_wrapper.hpp
+++ b/core/include/Core/pfd_wrapper.hpp
@@ -16,16 +16,16 @@ namespace mandeye::fd
         "Image files (*.bmp, *.jpg, *.jpeg, *.png)", "*.bmp *.jpg *.jpeg *.png", "All files", "*"
     };
 
-    const std::vector<std::string> Calibration_filter = { "Mandeye JSON Calibration (*.mjc)", "*.mjc", "Generic JSON (*.json)", "*.json" };
-    const std::vector<std::string> Session_filter = { "Mandeye JSON Session (*.mjs)", "*.mjs", "Generic JSON (*.json)", "*.json" };
-    const std::vector<std::string> Project_filter = { "Mandeye JSON Project (*.mjp)", "*.mjp", "Generic JSON (*.json)", "*.json" };
+    const std::vector<std::string> Calibration_filter = { "Mandeye JSON Calibration (*.mjc)", "*.mjc", "Generic JSON (*.json)", "*.json", "All files", "*" };
+    const std::vector<std::string> Session_filter = { "Mandeye JSON Session (*.mjs)", "*.mjs", "Generic JSON (*.json)", "*.json", "All files", "*" };
+    const std::vector<std::string> Project_filter = { "Mandeye JSON Project (*.mjp)", "*.mjp", "Generic JSON (*.json)", "*.json", "All files", "*" };
 
     const std::vector<std::string> IniPoses_filter = {
         "Mandeye REG Initial poses (*.mri)", "*.mri", "Generic REG initial poses (*.reg)", "*.reg"
     };
     const std::vector<std::string> Poses_filter = { "Mandeye REG Poses (*.mrp)", "*.mrp", "Generic REG poses (*.reg)", "*.reg" };
 
-    const std::vector<std::string> Resso_filter = { "RESSO (*.reg)", "*.reg" };
+    const std::vector<std::string> Resso_filter = { "RESSO (*.reg)", "*.reg", "All files", "*" };
     const std::vector<std::string> Dxf_filter = { "DXF file (*.dxf)", "*.dxf" };
     const std::vector<std::string> Csv_filter = { "CSV file (*.csv)", "*.csv" };
     const std::vector<std::string> Toml_filter = { "TOML file (*.toml)", "*.toml", "All files", "*" };


### PR DESCRIPTION
On macOS, portable-file-dialogs drives an AppleScript `choose file of type {...}` panel. When a filter has no catch-all entry, files whose extension macOS cannot resolve to a known UTI are greyed out and cannot be selected. Commit 65436ae fixed this for the TOML "Load parameters" dialog; the LAS/LAZ, JSON and SN filters already carried the fallback.

This applies the same fix to the remaining filters that are reachable from OpenFileDialog / OpenFileDialogOneFile (load) paths and still lacked it: Calibration (*.mjc), Session (*.mjs), Project (*.mjp) and Resso (*.reg).

Save-only filters (IniPoses, Poses, Dxf, Csv) are intentionally left unchanged: a save panel lets the user type a new name, so the missing catch-all does not block selection there. No behaviour change on Windows/Linux, where the typed filter remains the default.